### PR TITLE
Add an option to let the parser use a constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ If parser's `async` option is `true`, then a callback function has to be passed 
 argument. This callback should take two arguments like other node.js callbacks:
 `function(err, result)`.
 
+### create(constructorFunction)
+Set the constructor function that should be called to create the object returned from
+the `parse` method.
+
 ### [u]int{8, 16, 32}{le, be}(name [,options])
 Parse bytes as an integer and store it in a variable named `name`. `name` should consist
 only of alphanumeric characters and start with an alphabet.

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -62,6 +62,7 @@ var Parser = function() {
     this.compiled = null;
     this.isAsync = false;
     this.endian = 'be';
+    this.constructorFn = null;
 };
 
 //----------------------------------------------------------------------------------------
@@ -184,13 +185,27 @@ Parser.prototype.endianess = function(endianess) {
     return this;
 };
 
+Parser.prototype.create = function(constructorFn) {
+    if (!(constructorFn instanceof Function)) {
+        throw new Error('Constructor must be a Function object.');
+    }
+
+    this.constructorFn = constructorFn;
+
+    return this;
+};
+
 Parser.prototype.getCode = function() {
     var ctx = new Context();
     if (this.isAsync) {
         ctx.isAsync = true;
     }
 
-    ctx.pushCode('var vars = {};');
+    if (this.constructorFn) {
+        ctx.pushCode('var vars = new constructorFn();');
+    } else {
+        ctx.pushCode('var vars = {};');
+    }
     ctx.pushCode('var offset = 0;');
     ctx.pushCode('if (!Buffer.isBuffer(buffer)) {');
     ctx.generateError('"argument buffer is not a Buffer object"');
@@ -206,7 +221,7 @@ Parser.prototype.getCode = function() {
 };
 
 Parser.prototype.compile = function() {
-    this.compiled = new Function('buffer', 'callback', this.getCode());
+    this.compiled = new Function('buffer', 'callback', 'constructorFn', this.getCode());
 };
 
 Parser.prototype.sizeOf = function() {
@@ -250,7 +265,7 @@ Parser.prototype.parse = function(buffer, callback) {
         this.compile();
     }
 
-    return this.compiled(buffer, callback);
+    return this.compiled(buffer, callback, this.constructorFn);
 };
 
 //----------------------------------------------------------------------------------------

--- a/test/test.js
+++ b/test/test.js
@@ -466,6 +466,26 @@ describe('Parser', function(){
         });
     });
 
+    describe('Constructors', function() {
+        it('should create a custom object type', function() {
+           function Person () {
+             this.name = ''
+           };
+           Person.prototype.toString = function () { return '[object Person]'; };
+           var parser =
+               Parser.start()
+               .create(Person)
+               .string('name', {
+                   zeroTerminated: true
+               });
+
+           var buffer = new Buffer('John Doe\0');
+           var person = parser.parse(buffer);
+           assert.ok(person instanceof Person);
+           assert.equal(person.name, 'John Doe');
+        });
+    });
+
     describe('Utilities', function() {
         it('should count size for fixed size structs', function() {
             var parser =


### PR DESCRIPTION
This lets a parser return an object with a given prototype.

This is more for discussion right now ... What do you think?

I would find this useful for all sorts of things, in conjunction with nested parsers. Like, for example, parsing the MAC addresses from an Ethernet frame where it is useful for them to have a prototype that I can add custom `toString` and other functions ....

I don't know if there are issues with how this integrates with other parts of the system yet ... or if there's more flexibility needed.
