### PR TITLE
Added string parser the capabilities to strip null in order to correctly read null padded string

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ with an alphabet. `options` is an object; following options are available:
 
 - `encoding` - (Optional, defaults to `utf8`) Specify which encoding to use. `'utf8'`, `'ascii'`, `'hex'` and else
 	are valid. See [`Buffer.toString`](http://nodejs.org/api/buffer.html#buffer_buf_tostring_encoding_start_end) for more info.
-- `length ` - (Required) Length of the string. Can be a number, string or a function.
+- `length ` - (Optional) Length of the string. Can be a number, string or a function.
 	Use number for statically sized arrays, string to reference another variable and
 	function to do some calculation.
 - `zeroTerminated` - (Optional, defaults to `false`) If true, then this parser reads until it reaches zero.
+- `stripNull` - (Optional, must be used with `length`) If true, then strip null characters from end of the string
 
 ### buffer(name [,options])
 Parse bytes as a buffer. `name` should consist only of alpha numeric characters and start

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -392,7 +392,20 @@ Parser.prototype.generateSkip = function(ctx) {
 };
 
 Parser.prototype.generateString = function(ctx) {
-    if (this.options.zeroTerminated) {
+    if(this.options.length) {
+        var name = ctx.generateVariable(this.varName);
+        ctx.pushCode('{0} = buffer.toString(\'{1}\', offset, offset + {2});',
+                            name,
+                            this.options.encoding,
+                            ctx.generateOption(this.options.length)
+                        );
+        if(this.options.stripNull)
+        {
+            ctx.pushCode('{0} = {0}.replace(/\0/g, \'\')', name);
+        }
+        ctx.pushCode('offset += {0};', ctx.generateOption(this.options.length));
+    }
+    else {
         var start = ctx.generateTmpVariable();
 
         ctx.pushCode('var {0} = offset;', start);
@@ -403,14 +416,6 @@ Parser.prototype.generateString = function(ctx) {
             start
         );
     }
-     else {
-        ctx.pushCode('{0} = buffer.toString(\'{1}\', offset, offset + {2});',
-                            ctx.generateVariable(this.varName),
-                            this.options.encoding,
-                            ctx.generateOption(this.options.length)
-                        );
-        ctx.pushCode('offset += {0};', ctx.generateOption(this.options.length));
-     }
 };
 
 Parser.prototype.generateBuffer = function(ctx) {


### PR DESCRIPTION
I changed the string parser default behaviour (it will now assume null terminated string) and added an option for  fixed length string to be stripped of null characters (null-padded string).