### PR TITLE
Added formatter to array & nest and a readUntil function

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ Parse bytes as an array. `options` is an object; following options are available
 - `length` - (either `length` or `readUntil` is required) Length of the array. Can be a number, string or a function.
 	Use number for statically sized arrays.
 - `readUntil` - (either `length` or `readUntil` is required) If `'eof'`, then this parser
-	will read till it reaches end of the `Buffer` object.
+	reads until the end of `Buffer` object. If function it reads until the function returns true.
+- `formatter` - (Optional) Function that transforms the parsed array into a more desired form.
 
 ```javascript
 var parser = new Parser()
@@ -176,12 +177,25 @@ var parser = new Parser()
 		type: 'int32',
 		length: function() { return this.dataLength - 1; } // other fields are available through this
 	});
+
+	// Dynamically sized array (with stop-check on parsed item)
+	.array('data4', {
+		type: 'int32',
+		readUntil: function(item, buffer) { return item === 42 } // stop when specific item is parsed. buffer can be used to perform a read-ahead.
+	});
 	
 	// Use user defined parser object
-	.array('data4', {
+	.array('data5', {
 		type: userDefinedParser,
 		length: 'dataLength'
-	})
+	});
+
+	// Use formatter to transform parsed array
+	.array('ipv4', {
+		type: uint8,
+		length: '4',
+		formatter: function(arr) { return arr.join('.'); }
+	});
 ```
 
 ### choice(name [,options])
@@ -217,6 +231,7 @@ Nest a parser in this position. Parse result of the nested parser is stored in t
 `name`.
 
 - `type` - (Required) A `Parser` object.
+- `formatter` - (Optional) Function that transforms the parsed nested type into a more desired form.
 
 ### skip(length)
 Skip parsing for `length` bytes.

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -493,6 +493,10 @@ Parser.prototype.generateArray = function(ctx) {
     }
 
     ctx.pushCode('}');
+
+    if (this.options.formatter) {
+        this.generateFormatter(ctx, lhs, this.options.formatter);
+    }
 };
 
 Parser.prototype.generateChoiceCase = function(ctx, varName, type) {
@@ -532,7 +536,17 @@ Parser.prototype.generateNest = function(ctx) {
     ctx.pushPath(this.varName);
     this.options.type.generate(ctx);
     ctx.popPath();
+
+    if (this.options.formatter) {
+        this.generateFormatter(ctx, varName, this.options.formatter);
+    }
 };
+
+Parser.prototype.generateFormatter = function(ctx, varName, formatter) {
+    if (typeof formatter === 'function') {
+        ctx.pushCode('{0} = ({1}).call(this, {0});', varName, formatter);
+    }
+}
 
 Parser.prototype.isInteger = function() {
     return !!this.type.match(/U?Int[8|16|32][BE|LE]?|Bit\d+/);

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -469,7 +469,9 @@ Parser.prototype.generateArray = function(ctx) {
     } else {
         ctx.pushCode('{0} = [];', lhs);
     }
-    if (this.options.readUntil === 'eof') {
+    if (typeof this.options.readUntil === 'function') {
+        ctx.pushCode('do {');
+    } else if (this.options.readUntil === 'eof') {
         ctx.pushCode('for (var {0} = 0; offset < buffer.length; {0}++) {', counter);
     } else {
         ctx.pushCode('for (var {0} = 0; {0} < {1}; {0}++) {', counter, length);
@@ -494,6 +496,9 @@ Parser.prototype.generateArray = function(ctx) {
 
     ctx.pushCode('}');
 
+    if (typeof this.options.readUntil === 'function') {
+        ctx.pushCode(' while (!({0}).call(this, {1}, buffer.slice(offset)));', this.options.readUntil, item);
+    }
     if (this.options.formatter) {
         this.generateFormatter(ctx, lhs, this.options.formatter);
     }

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -537,13 +537,14 @@ Parser.prototype.generateChoice = function(ctx) {
 };
 
 Parser.prototype.generateNest = function(ctx) {
-    ctx.pushCode('{0} = {};', ctx.generateVariable(this.varName));
+    var nestVar = ctx.generateVariable(this.varName);
+    ctx.pushCode('{0} = {};', nestVar);
     ctx.pushPath(this.varName);
     this.options.type.generate(ctx);
     ctx.popPath();
 
     if (this.options.formatter) {
-        this.generateFormatter(ctx, varName, this.options.formatter);
+        this.generateFormatter(ctx, nestVar, this.options.formatter);
     }
 };
 


### PR DESCRIPTION
I was using your excellent module to make a parser for DNS packets and ran into a few issues that led me to implement a few new features that I thought you might want to integrate.

I added a formatter option to `array` and `nest` type, used like so:
```
var ARecord = new Parser()
    .array('ipv4', {
        type: 'uint8',
        length: 4,
        formatter: function(arr) { return arr.join('.'); }
    });
```

And for `readUntil` in array type I made it possible to use a function, like so:
```
// Fully qualified domain name, as per http://tools.ietf.org/html/rfc1035 @ 4.1.4
var fqdnPart = new Parser()
    .uint8('len')
    .string('label', {
        length: function() { return (this.len >> 6 === 3 ? 1 : this.len); }
    });
var fqdn = new Parser()
    .array('fqdnParts', {
        type: fqdnPart,
        readUntil: function(lastItem, buf) {
            // Read parts until a null byte or ptr has been read.
            return lastItem.len === 0 || (lastItem.len >> 6) === 3;
        }
    });
```
I send `lastItem` to the `readUntil` function so it's possible to react to a "stop-element" used in many formats. The buffer at current offset is also passed in case a read-ahead is needed.


I'll happily do changes you suggest or re-PR with just one of the features if you like. Just let me know.