### PR TITLE
Add a prefixLengthType option in array/string for parsing data like '…

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ with an alphabet. `options` is an object; following options are available:
 	function to do some calculation.
 - `zeroTerminated` - (Optional, defaults to `false`) If true, then this parser reads until it reaches zero.
 - `stripNull` - (Optional, must be used with `length`) If true, then strip null characters from end of the string
+- `prefixLengthType` - (Optional), can be a primitive type, then this parser reads the primitive
+        from the buffer, and use it as the array length to be read.
+
 
 ### buffer(name [,options])
 Parse bytes as a buffer. `name` should consist only of alpha numeric characters and start
@@ -147,10 +150,12 @@ Parse bytes as an array. `options` is an object; following options are available
 
 - `type` - (Required) Type of the array element. Can be a string or an user defined Parser object.
     If it's a string, you have to choose from [u]int{8, 16, 32}{le, be}.
-- `length` - (either `length` or `readUntil` is required) Length of the array. Can be a number, string or a function.
+- `length` - (either `length` or `readUntil` or `prefixLengthType` is required) Length of the array. Can be a number, string or a function.
 	Use number for statically sized arrays.
-- `readUntil` - (either `length` or `readUntil` is required) If `'eof'`, then this parser
+- `readUntil` - (either `length` or `readUntil` or `prefixLengthType` is required) If `'eof'`, then this parser
 	reads until the end of `Buffer` object. If function it reads until the function returns true.
+- `prefixLengthType` - (either `length` or `readUntil` or `prefixLengthType` is required), can be a primitive type, then this parser reads the primitive
+        from the buffer, and use it as the array length to be read.
 
 ```javascript
 var parser = new Parser()

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -107,7 +107,7 @@ Parser.prototype.skip = function(length, options) {
 };
 
 Parser.prototype.string = function(varName, options) {
-    if (!options.zeroTerminated && !options.length) {
+    if (!options.zeroTerminated && !options.length && !options.prefixLengthType) {
         throw new Error('Length option of string is not defined.');
     }
     options.encoding = options.encoding || 'utf8';
@@ -124,7 +124,7 @@ Parser.prototype.buffer = function(varName, options) {
 };
 
 Parser.prototype.array = function(varName, options) {
-    if (!options.readUntil && !options.length) {
+    if (!options.readUntil && !options.length && !options.prefixLengthType) {
         throw new Error('Length option of array is not defined.');
     }
     if (!options.type) {
@@ -403,8 +403,17 @@ Parser.prototype.generateString = function(ctx) {
             ctx.pushCode('{0} = {0}.replace(/\0/g, \'\')', name);
         }
         ctx.pushCode('offset += {0};', ctx.generateOption(this.options.length));
-    }
-    else {
+    } else if (this.options.prefixLengthType) {
+        var length = ctx.generateTmpVariable();
+        var type = this.options.prefixLengthType;
+        ctx.pushCode('var {0} = buffer.read{1}(offset);', length, NAME_MAP[type]);
+        ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+
+        ctx.pushCode('{0} = buffer.toString(\'{1}\', offset, offset + {2});',
+		     ctx.generateVariable(this.varName),
+		     this.options.encoding,
+		     length);
+    } else {
         var start = ctx.generateTmpVariable();
 
         ctx.pushCode('var {0} = offset;', start);
@@ -447,6 +456,7 @@ Parser.prototype.generateArray = function(ctx) {
     var item = ctx.generateTmpVariable();
     var key = this.options.key;
     var isHash = typeof key === 'string';
+    var prefixLengthType = this.options.prefixLengthType;
 
     if (isHash) {
         ctx.pushCode('{0} = {};', lhs);
@@ -457,6 +467,11 @@ Parser.prototype.generateArray = function(ctx) {
         ctx.pushCode('do {');
     } else if (this.options.readUntil === 'eof') {
         ctx.pushCode('for (var {0} = 0; offset < buffer.length; {0}++) {', counter);
+    } else if (this.options.prefixLengthType) {
+	var arrayLength = ctx.generateTmpVariable();
+	ctx.pushCode('var {0} = buffer.read{1}(offset);', arrayLength, NAME_MAP[prefixLengthType]);
+	ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[prefixLengthType]]);
+	ctx.pushCode('for (var {0} = 0; {0} < {1}; {0}++) {', counter, arrayLength);
     } else {
         ctx.pushCode('for (var {0} = 0; {0} < {1}; {0}++) {', counter, length);
     }

--- a/test/composite_parser.js
+++ b/test/composite_parser.js
@@ -177,6 +177,19 @@ describe('Composite parser', function(){
                 data: '10.10.1.110'
             });
         });
+
+	it('should parse array with option prefixLengthType', function () {
+	    var parser =
+		Parser.start()
+		.array('data', {
+		    prefixLengthType: 'uint8',
+		    type: 'uint8',
+		});
+	    var buffer = new Buffer([3, 2, 3, 4]);
+	    assert.deepEqual(parser.parse(buffer), {
+		data: [2, 3, 4],
+	    });
+	});
     });
 
     describe('Choice parser', function() {

--- a/test/primitive_parser.js
+++ b/test/primitive_parser.js
@@ -232,6 +232,15 @@ describe('Primitive parser', function(){
 
             assert.deepEqual(parser.parse(buffer), {msg: 'hello, world'});
         });
+	it('should parse string with option prefixLengthType', function() {
+            var buffer = new Buffer('0c68656c6c6f2c20776f726c64', 'hex');
+            var parser = Parser.start()
+                .string('msg', {
+		    encoding: 'utf8',
+		    prefixLengthType: 'uint8',
+		});
+            assert.equal(parser.parse(buffer).msg, 'hello, world');
+	});
     });
 
     describe('Buffer parser', function() {


### PR DESCRIPTION
…NUM[NUM OF ITEMS]'.

Instead of parser.uint8('fooLength').array('foo', {type: 'bar', length: 'fooLength'}), we can now write
as parser.array('foo', {type: 'bar', prefixLengthType: 'uint8'}), this also removes the fooLength from parsed output.