### PR TITLE
Enable Strings as choice keys

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -148,9 +148,6 @@ Parser.prototype.choice = function(varName, options) {
         throw new Error('Choices option of array is not defined.');
     }
     Object.keys(options.choices).forEach(function(key) {
-        if (isNaN(parseInt(key, 10))) {
-            throw new Error('Key of choices must be a number.');
-        }
         if (!options.choices[key]) {
             throw new Error('Choice Case ' + key + ' of ' + varName + ' is not valid.');
         }
@@ -524,7 +521,7 @@ Parser.prototype.generateChoice = function(ctx) {
     Object.keys(this.options.choices).forEach(function(tag) {
         var type = this.options.choices[tag];
 
-        ctx.pushCode('case {0}:', tag);
+        ctx.pushCode('case ' + (isNaN(tag) ? '"{0}"' : '{0}') + ':', tag);
         this.generateChoiceCase(ctx, this.varName, type);
         ctx.pushCode('break;');
     }, this);


### PR DESCRIPTION
Checks during the parser generation if a choice key is a number, otherwise insert some quotes. This allows to match strings for tags as well.