### PR TITLE
Add 'greedy' option to strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ with an alphabet. `options` is an object; following options are available:
 	Use number for statically sized arrays, string to reference another variable and
 	function to do some calculation.
 - `zeroTerminated` - (Optional, defaults to `false`) If true, then this parser reads until it reaches zero.
+- `greedy - (Optional, defaults to `false`) If true, then this parser reads until it reaches the end of the buffer. Will consume zero-bytes.
 - `stripNull` - (Optional, must be used with `length`) If true, then strip null characters from end of the string
 
 ### buffer(name [,options])

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -107,11 +107,14 @@ Parser.prototype.skip = function(length, options) {
 };
 
 Parser.prototype.string = function(varName, options) {
-    if (!options.zeroTerminated && !options.length) {
-        throw new Error('Neiter length nor zeroTerminated is defined for string.');
+    if (!options.zeroTerminated && !options.length && !options.greedy) {
+        throw new Error('Neither length, zeroTerminated, nor greedy is defined for string.');
     }
-    if (options.stripNull && !options.length) {
-        throw new Error('Length must be defined if stripNull is defined.');
+    if ((options.zeroTerminated || options.length) && options.greedy) {
+        throw new Error('greedy is mutually exclusive with length and zeroTerminated for string.');
+    }
+    if (options.stripNull && !(options.length || options.greedy)) {
+        throw new Error('Length or greedy must be defined if stripNull is defined.');
     }
     options.encoding = options.encoding || 'utf8';
 
@@ -427,6 +430,14 @@ Parser.prototype.generateString = function(ctx) {
         ctx.pushCode('var {0} = offset;', start);
         ctx.pushCode('while(buffer.readUInt8(offset++) !== 0);');
         ctx.pushCode('{0} = buffer.toString(\'{1}\', {2}, offset - 1);',
+            name,
+            this.options.encoding,
+            start
+        );
+    } else if (this.options.greedy) {
+        ctx.pushCode('var {0} = offset;', start);
+        ctx.pushCode('while(buffer.length > offset && buffer.readUInt8(offset++) !== 0);');
+        ctx.pushCode('{0} = buffer.toString(\'{1}\', {2}, offset);',
             name,
             this.options.encoding,
             start

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -436,7 +436,7 @@ Parser.prototype.generateString = function(ctx) {
         );
     } else if (this.options.greedy) {
         ctx.pushCode('var {0} = offset;', start);
-        ctx.pushCode('while(buffer.length > offset && buffer.readUInt8(offset++) !== 0);');
+        ctx.pushCode('while(buffer.length > offset++);');
         ctx.pushCode('{0} = buffer.toString(\'{1}\', {2}, offset);',
             name,
             this.options.encoding,

--- a/test/primitive_parser.js
+++ b/test/primitive_parser.js
@@ -253,6 +253,15 @@ describe('Primitive parser', function(){
             assert.equal(parser1.parse(buffer).str, 'test\u0000\u0000');
             assert.equal(parser2.parse(buffer).str, 'test');
         });
+        it('should parse string greedily with zero-bytes internally', function() {
+            var buffer = new Buffer('abc\u0000defghij\u0000');
+            var parser = Parser.start()
+                .string('a', {greedy: true});
+
+            assert.deepEqual(parser.parse(buffer), {
+                a: 'abc\u0000defghij\u0000'
+            });
+        });
     });
 
     describe('Buffer parser', function() {


### PR DESCRIPTION
Add 'greedy' option to strings: parses until a null character or end of the stream is found.

We've found this useful at Swift for parsing our binary format. A similar feature is supported in the Python Construct library that does the same thing: https://github.com/construct/construct/pull/59
