### PR TITLE
Add rewind to enable reprocessing of data as necessary.

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -26,6 +26,7 @@ var SPECIAL_TYPES = {
     'Buffer'   : null,
     'Array'    : null,
     'Skip'     : null,
+    'Rewind'   : null,
     'Choice'   : null,
     'Nest'     : null,
     'Bit'      : null
@@ -104,6 +105,14 @@ Parser.prototype.skip = function(length, options) {
     }
 
     return this.setNextParser('skip', '', {length: length});
+};
+
+Parser.prototype.rewind = function(length, options) {
+    if (options && options.assert) {
+        throw new Error('assert option on rewind is not allowed.');
+    }
+
+    return this.setNextParser('rewind', '', {length: length});
 };
 
 Parser.prototype.string = function(varName, options) {
@@ -243,8 +252,8 @@ Parser.prototype.sizeOf = function() {
         }
         size = this.options.length * elementSize;
 
-    // if this a skip
-    } else if (this.type === 'Skip') {
+    // if this a skip or rewind
+    } else if (this.type === 'Skip' || this.type === 'Rewind') {
         size = this.options.length;
 
     } else if (!this.type) {
@@ -397,6 +406,11 @@ Parser.prototype.generateBit = function(ctx) {
 
 Parser.prototype.generateSkip = function(ctx) {
     var length = ctx.generateOption(this.options.length);
+    ctx.pushCode('offset += {0};', length);
+};
+
+Parser.prototype.generateRewind = function(ctx) {
+    var length = -ctx.generateOption(this.options.length);
     ctx.pushCode('offset += {0};', length);
 };
 

--- a/test/primitive_parser.js
+++ b/test/primitive_parser.js
@@ -69,6 +69,22 @@ describe('Primitive parser', function(){
             var buffer = new Buffer([0x00, 0xff, 0xff, 0xfe, 0xd2, 0x04, 0x00, 0xbc, 0x61, 0x4e]);
             assert.deepEqual(parser.parse(buffer), {a: 0, b: 1234, c: 12345678});
         });
+        it('should rewind when specified', function(){
+            var parser =
+            Parser.start()
+            .uint8('a')
+            .rewind(1)
+            .uint8('b')
+            .uint8('c')
+            .rewind(1)
+            .uint8('d')
+            .uint32be('e')
+            .rewind(4)
+            .uint32be('f');
+
+            var buffer = new Buffer([0x00, 0xff, 0xff, 0xfe, 0xd2, 0x04, 0x00, 0xbc, 0x61, 0x4e]);
+            assert.deepEqual(parser.parse(buffer), {a: 0, b:0, c: 255, d: 255, e: 4294889988, f: 4294889988});
+        });
     });
 
     describe('Bit field parsers', function() {


### PR DESCRIPTION
Allows data to control flow and be a value as well by enabling rewind. An example is where a byte is used as a branch when it has a value of 0 or 255, but if it is any other value X, then read X bytes. From what I could tell this case was not possible because the byte would be consumed in the choice. Obviously care must be taken with endianness. 
