### PR TITLE
Added support for nested parsers in sizeOf function

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -247,6 +247,9 @@ Parser.prototype.sizeOf = function() {
     } else if (this.type === 'Skip') {
         size = this.options.length;
 
+    // if this is a nested parser
+    } else if (this.type === 'Nest') {
+        size = this.options.type.sizeOf();   
     } else if (!this.type) {
         size = 0;
     }


### PR DESCRIPTION
Previously, the sizeOf() function would return NaN if the parser contained a nested parser. The 'Nest' type was an unhandled case in this function; to handle it all you need to do is call the nested parser's own sizeOf() function. I don't think you even really need to check that this.options.type is of a Parser object, since that is ensured in nest()
