### PR TITLE
Recursion, method `namely`

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -31,7 +31,8 @@ var SPECIAL_TYPES = {
     'Bit'      : null
 };
 
-var RECURSION_FN = '__d_e_l_t_r_o_n_3_0_0_0';
+var aliasRegistry = {};
+var FUNCTION_PREFIX = '___parser_';
 
 var BIT_RANGE = [];
 (function() {
@@ -66,7 +67,7 @@ var Parser = function() {
     this.compiled = null;
     this.endian = 'be';
     this.constructorFn = null;
-    this.recursive = null;
+    this.alias = null;
 };
 
 //----------------------------------------------------------------------------------------
@@ -101,8 +102,9 @@ BIT_RANGE.forEach(function(i) {
     };
 });
 
-Parser.prototype.recursiveAs = function(label) {
-    this.recursive = label || 'self';
+Parser.prototype.namely = function(alias) {
+    aliasRegistry[alias] = this;
+    this.alias = alias;
     return this;
 }
 
@@ -141,8 +143,7 @@ Parser.prototype.array = function(varName, options) {
     if (!options.type) {
         throw new Error('Type option of array is not defined.');
     }
-    if ((typeof options.type === 'string')
-        && (!this.recursive || (this.recursive !== options.type))
+    if ((typeof options.type === 'string') && !aliasRegistry[options.type]
         && Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.type]) < 0) {
         throw new Error('Specified primitive type "' + options.type + '" is not supported.');
     }
@@ -165,8 +166,7 @@ Parser.prototype.choice = function(varName, options) {
             throw new Error('Choice Case ' + key + ' of ' + varName + ' is not valid.');
         }
 
-        if ((typeof options.choices[key] === 'string')
-            && (!this.recursive || (this.recursive !== options.choices[key]))
+        if ((typeof options.choices[key] === 'string') && !aliasRegistry[options.choices[key]]
             && (Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.choices[key]]) < 0)) {
             throw new Error('Specified primitive type "' +  options.choices[key] + '" is not supported.');
         }
@@ -180,8 +180,7 @@ Parser.prototype.nest = function(varName, options) {
         throw new Error('Type option of nest is not defined.');
     }
 
-    if (!(options.type instanceof Parser)
-        && (!this.recursive || (this.recursive !== options.type))) {
+    if (!(options.type instanceof Parser) && !aliasRegistry[options.type]) {
         throw new Error('Type option of nest must be a Parser object.');
     }
 
@@ -216,8 +215,12 @@ Parser.prototype.create = function(constructorFn) {
 Parser.prototype.getCode = function() {
     var ctx = new Context();
 
-    if (this.recursive) {
-        ctx.pushCode('function {0}(offset) {', RECURSION_FN);
+    ctx.pushCode('if (!Buffer.isBuffer(buffer)) {');
+    ctx.generateError('"argument buffer is not a Buffer object"');
+    ctx.pushCode('}');
+
+    if (this.alias) {
+        ctx.pushCode('function {0}(offset) {', FUNCTION_PREFIX + this.alias);
     } else {
         ctx.pushCode('var offset = 0;');
     }
@@ -228,16 +231,12 @@ Parser.prototype.getCode = function() {
         ctx.pushCode('var vars = {};');
     }
 
-    ctx.pushCode('if (!Buffer.isBuffer(buffer)) {');
-    ctx.generateError('"argument buffer is not a Buffer object"');
-    ctx.pushCode('}');
-
     this.generate(ctx);
 
-    if (this.recursive) {
+    if (this.alias) {
         ctx.pushCode('return { offset: offset, result: vars };');
         ctx.pushCode('}');
-        ctx.pushCode('return {0}(0).result;', RECURSION_FN);
+        ctx.pushCode('return {0}(0).result;', FUNCTION_PREFIX + this.alias);
     } else {
         ctx.pushCode('return vars;');
     }
@@ -304,7 +303,6 @@ Parser.prototype.setNextParser = function(type, varName, options) {
     parser.varName = varName;
     parser.options = options || parser.options;
     parser.endian = this.endian;
-    parser.recursive = this.recursive;
 
     if (this.head) {
         this.head.next = parser;
@@ -509,13 +507,13 @@ Parser.prototype.generateArray = function(ctx) {
     }
 
     if (typeof type === 'string') {
-        if (this.recursive && (type === this.recursive)) {
-            var tempVar = ctx.generateTmpVariable();
-            ctx.pushCode('var {0} = {1}(offset);', tempVar, RECURSION_FN);
-            ctx.pushCode('var {0} = {1}.result; offset += {1}.offset;', item, tempVar);
-        } else {
+        if (!aliasRegistry[type]) {
             ctx.pushCode('var {0} = buffer.read{1}(offset);', item, NAME_MAP[type]);
             ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+        } else {
+            var tempVar = ctx.generateTmpVariable();
+            ctx.pushCode('var {0} = {1}(offset);', tempVar, FUNCTION_PREFIX + type);
+            ctx.pushCode('var {0} = {1}.result; offset = {1}.offset;', item, tempVar);
         }
     } else if (type instanceof Parser) {
         ctx.pushCode('var {0} = {};', item);
@@ -540,13 +538,13 @@ Parser.prototype.generateArray = function(ctx) {
 
 Parser.prototype.generateChoiceCase = function(ctx, varName, type) {
     if (typeof type === 'string') {
-        if (this.recursive && (type === this.recursive)) {
-            var tempVar = ctx.generateTmpVariable();
-            ctx.pushCode('var {0} = {1}(offset);', tempVar, RECURSION_FN);
-            ctx.pushCode('{0} = {1}.result; offset += {1}.offset;', ctx.generateVariable(this.varName), tempVar);
-        } else {
+        if (!aliasRegistry[type]) {
             ctx.pushCode('{0} = buffer.read{1}(offset);', ctx.generateVariable(this.varName), NAME_MAP[type]);
             ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+        } else {
+            var tempVar = ctx.generateTmpVariable();
+            ctx.pushCode('var {0} = {1}(offset);', tempVar, FUNCTION_PREFIX + type);
+            ctx.pushCode('{0} = {1}.result; offset = {1}.offset;', ctx.generateVariable(this.varName), tempVar);
         }
     } else if (type instanceof Parser) {
         ctx.pushPath(varName);
@@ -578,10 +576,16 @@ Parser.prototype.generateChoice = function(ctx) {
 
 Parser.prototype.generateNest = function(ctx) {
     var nestVar = ctx.generateVariable(this.varName);
-    ctx.pushCode('{0} = {};', nestVar);
-    ctx.pushPath(this.varName);
-    this.options.type.generate(ctx);
-    ctx.popPath();
+    if (this.options.type instanceof Parser) {
+        ctx.pushCode('{0} = {};', nestVar);
+        ctx.pushPath(this.varName);
+        this.options.type.generate(ctx);
+        ctx.popPath();
+    } else if (aliasRegistry[this.options.type]) {
+        var tempVar = ctx.generateTmpVariable();
+        ctx.pushCode('var {0} = {1}(offset);', tempVar, FUNCTION_PREFIX + this.options.type);
+        ctx.pushCode('{0} = {1}.result; offset = {1}.offset;', nestVar, tempVar);
+    }
 };
 
 Parser.prototype.generateFormatter = function(ctx, varName, formatter) {

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -219,11 +219,23 @@ Parser.prototype.getCode = function() {
     ctx.generateError('"argument buffer is not a Buffer object"');
     ctx.pushCode('}');
 
-    if (this.alias) {
-        ctx.pushCode('function {0}(offset) {', FUNCTION_PREFIX + this.alias);
+    if (!this.alias) {
+        this.addRawCode(ctx);
     } else {
-        ctx.pushCode('var offset = 0;');
+        this.addAliasedCode(ctx);
     }
+
+    if (this.alias) {
+        ctx.pushCode('return {0}(0).result;', FUNCTION_PREFIX + this.alias);
+    } else {
+        ctx.pushCode('return vars;');
+    }
+
+    return ctx.code;
+};
+
+Parser.prototype.addRawCode = function(ctx) {
+    ctx.pushCode('var offset = 0;');
 
     if (this.constructorFn) {
         ctx.pushCode('var vars = new constructorFn();');
@@ -233,15 +245,38 @@ Parser.prototype.getCode = function() {
 
     this.generate(ctx);
 
-    if (this.alias) {
-        ctx.pushCode('return { offset: offset, result: vars };');
-        ctx.pushCode('}');
-        ctx.pushCode('return {0}(0).result;', FUNCTION_PREFIX + this.alias);
+    this.resolveReferences(ctx);
+
+    ctx.pushCode('return vars;');
+};
+
+Parser.prototype.addAliasedCode = function(ctx) {
+    ctx.pushCode('function {0}(offset) {', FUNCTION_PREFIX + this.alias);
+
+    if (this.constructorFn) {
+        ctx.pushCode('var vars = new constructorFn();');
     } else {
-        ctx.pushCode('return vars;');
+        ctx.pushCode('var vars = {};');
     }
 
-    return ctx.code;
+    this.generate(ctx);
+
+    ctx.markResolved(this.alias);
+    this.resolveReferences(ctx);
+
+    ctx.pushCode('return { offset: offset, result: vars };');
+    ctx.pushCode('}');
+
+    return ctx;
+};
+
+Parser.prototype.resolveReferences = function(ctx) {
+    var references = ctx.getUnresolvedReferences();
+    ctx.markRequested(references);
+    references.forEach(function(alias) {
+        var parser = aliasRegistry[alias];
+        parser.addAliasedCode(ctx);
+    });
 };
 
 Parser.prototype.compile = function() {
@@ -514,6 +549,7 @@ Parser.prototype.generateArray = function(ctx) {
             var tempVar = ctx.generateTmpVariable();
             ctx.pushCode('var {0} = {1}(offset);', tempVar, FUNCTION_PREFIX + type);
             ctx.pushCode('var {0} = {1}.result; offset = {1}.offset;', item, tempVar);
+            if (type !== this.alias) ctx.addReference(type);
         }
     } else if (type instanceof Parser) {
         ctx.pushCode('var {0} = {};', item);
@@ -545,6 +581,7 @@ Parser.prototype.generateChoiceCase = function(ctx, varName, type) {
             var tempVar = ctx.generateTmpVariable();
             ctx.pushCode('var {0} = {1}(offset);', tempVar, FUNCTION_PREFIX + type);
             ctx.pushCode('{0} = {1}.result; offset = {1}.offset;', ctx.generateVariable(this.varName), tempVar);
+            if (type !== this.alias) ctx.addReference(type);
         }
     } else if (type instanceof Parser) {
         ctx.pushPath(varName);
@@ -585,6 +622,7 @@ Parser.prototype.generateNest = function(ctx) {
         var tempVar = ctx.generateTmpVariable();
         ctx.pushCode('var {0} = {1}(offset);', tempVar, FUNCTION_PREFIX + this.options.type);
         ctx.pushCode('{0} = {1}.result; offset = {1}.offset;', nestVar, tempVar);
+        if (this.options.type !== this.alias) ctx.addReference(this.options.type);
     }
 };
 

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -31,6 +31,8 @@ var SPECIAL_TYPES = {
     'Bit'      : null
 };
 
+var RECURSION_FN = '__d_e_l_t_r_o_n_3_0_0_0';
+
 var BIT_RANGE = [];
 (function() {
     var i;
@@ -64,6 +66,7 @@ var Parser = function() {
     this.compiled = null;
     this.endian = 'be';
     this.constructorFn = null;
+    this.recursive = null;
 };
 
 //----------------------------------------------------------------------------------------
@@ -97,6 +100,11 @@ BIT_RANGE.forEach(function(i) {
         return this.setNextParser('bit', varName, options);
     };
 });
+
+Parser.prototype.recursiveAs = function(label) {
+    this.recursive = label || 'self';
+    return this;
+}
 
 Parser.prototype.skip = function(length, options) {
     if (options && options.assert) {
@@ -133,7 +141,9 @@ Parser.prototype.array = function(varName, options) {
     if (!options.type) {
         throw new Error('Type option of array is not defined.');
     }
-    if (typeof options.type === 'string' && Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.type]) < 0) {
+    if ((typeof options.type === 'string')
+        && (!this.recursive || (this.recursive !== options.type))
+        && Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.type]) < 0) {
         throw new Error('Specified primitive type "' + options.type + '" is not supported.');
     }
 
@@ -155,10 +165,12 @@ Parser.prototype.choice = function(varName, options) {
             throw new Error('Choice Case ' + key + ' of ' + varName + ' is not valid.');
         }
 
-        if (typeof options.choices[key] === 'string' && Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.choices[key]]) < 0) {
+        if ((typeof options.choices[key] === 'string')
+            && (!this.recursive || (this.recursive !== options.choices[key]))
+            && (Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.choices[key]]) < 0)) {
             throw new Error('Specified primitive type "' +  options.choices[key] + '" is not supported.');
         }
-    });
+    }, this);
 
     return this.setNextParser('choice', varName, options);
 };
@@ -167,7 +179,9 @@ Parser.prototype.nest = function(varName, options) {
     if (!options.type) {
         throw new Error('Type option of nest is not defined.');
     }
-    if (!(options.type instanceof Parser)) {
+
+    if (!(options.type instanceof Parser)
+        && (!this.recursive || (this.recursive !== options.type))) {
         throw new Error('Type option of nest must be a Parser object.');
     }
 
@@ -202,19 +216,31 @@ Parser.prototype.create = function(constructorFn) {
 Parser.prototype.getCode = function() {
     var ctx = new Context();
 
+    if (this.recursive) {
+        ctx.pushCode('function {0}(offset) {', RECURSION_FN);
+    } else {
+        ctx.pushCode('var offset = 0;');
+    }
+
     if (this.constructorFn) {
         ctx.pushCode('var vars = new constructorFn();');
     } else {
         ctx.pushCode('var vars = {};');
     }
-    ctx.pushCode('var offset = 0;');
+
     ctx.pushCode('if (!Buffer.isBuffer(buffer)) {');
     ctx.generateError('"argument buffer is not a Buffer object"');
     ctx.pushCode('}');
 
     this.generate(ctx);
 
-    ctx.pushCode('return vars;');
+    if (this.recursive) {
+        ctx.pushCode('return { offset: offset, result: vars };');
+        ctx.pushCode('}');
+        ctx.pushCode('return {0}(0).result;', RECURSION_FN);
+    } else {
+        ctx.pushCode('return vars;');
+    }
 
     return ctx.code;
 };
@@ -278,6 +304,7 @@ Parser.prototype.setNextParser = function(type, varName, options) {
     parser.varName = varName;
     parser.options = options || parser.options;
     parser.endian = this.endian;
+    parser.recursive = this.recursive;
 
     if (this.head) {
         this.head.next = parser;
@@ -482,8 +509,14 @@ Parser.prototype.generateArray = function(ctx) {
     }
 
     if (typeof type === 'string') {
-        ctx.pushCode('var {0} = buffer.read{1}(offset);', item, NAME_MAP[type]);
-        ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+        if (this.recursive && (type === this.recursive)) {
+            var tempVar = ctx.generateTmpVariable();
+            ctx.pushCode('var {0} = {1}(offset);', tempVar, RECURSION_FN);
+            ctx.pushCode('var {0} = {1}.result; offset += {1}.offset;', item, tempVar);
+        } else {
+            ctx.pushCode('var {0} = buffer.read{1}(offset);', item, NAME_MAP[type]);
+            ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+        }
     } else if (type instanceof Parser) {
         ctx.pushCode('var {0} = {};', item);
 
@@ -507,8 +540,14 @@ Parser.prototype.generateArray = function(ctx) {
 
 Parser.prototype.generateChoiceCase = function(ctx, varName, type) {
     if (typeof type === 'string') {
-        ctx.pushCode('{0} = buffer.read{1}(offset);', ctx.generateVariable(this.varName), NAME_MAP[type]);
-        ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+        if (this.recursive && (type === this.recursive)) {
+            var tempVar = ctx.generateTmpVariable();
+            ctx.pushCode('var {0} = {1}(offset);', tempVar, RECURSION_FN);
+            ctx.pushCode('{0} = {1}.result; offset += {1}.offset;', ctx.generateVariable(this.varName), tempVar);
+        } else {
+            ctx.pushCode('{0} = buffer.read{1}(offset);', ctx.generateVariable(this.varName), NAME_MAP[type]);
+            ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+        }
     } else if (type instanceof Parser) {
         ctx.pushPath(varName);
         type.generate(ctx);

--- a/lib/context.js
+++ b/lib/context.js
@@ -12,6 +12,7 @@ var Context = function() {
     this.isAsync = false;
     this.bitFields = [];
     this.tmpVariableCount = 0;
+    this.references = {};
 };
 
 //----------------------------------------------------------------------------------------
@@ -57,7 +58,7 @@ Context.prototype.generateTmpVariable = function() {
 
 Context.prototype.pushCode = function() {
     var args = Array.prototype.slice.call(arguments);
- 
+
     this.code += Context.interpolate.apply(this, args) + '\n';
 };
 
@@ -75,6 +76,28 @@ Context.prototype.pushScope = function(name) {
 
 Context.prototype.popScope = function() {
     this.scopes.pop();
+};
+
+Context.prototype.addReference = function(alias) {
+    if (this.references[alias]) return;
+    this.references[alias] = { resolved: false, requested: false };
+};
+
+Context.prototype.markResolved = function(alias) {
+    this.references[alias].resolved = true;
+};
+
+Context.prototype.markRequested = function(aliasList) {
+    aliasList.forEach(function(alias) {
+        this.references[alias].requested = true;
+    }.bind(this));
+};
+
+Context.prototype.getUnresolvedReferences = function() {
+    var references = this.references;
+    return Object.keys(this.references).filter(function(alias) {
+        return !references[alias].resolved && !references[alias].requested;
+    });
 };
 
 //----------------------------------------------------------------------------------------

--- a/test/composite_parser.js
+++ b/test/composite_parser.js
@@ -179,7 +179,7 @@ describe('Composite parser', function(){
         });
         it('should be able to go into recursion', function(){
             var parser =
-                Parser.start().recursiveAs('self')
+                Parser.start().namely('self')
                 .uint8('length')
                 .array('data', {
                     type: 'self',
@@ -195,6 +195,50 @@ describe('Composite parser', function(){
                         length: 1,
                         data: [ { length: 0, data: [] } ]
                     } ]
+                } ]
+            });
+        });
+        it('should be able to go into even deeper recursion', function(){
+            var parser =
+                Parser.start().namely('self')
+                .uint8('length')
+                .array('data', {
+                    type: 'self',
+                    length: 'length'
+                });
+
+            //        2
+            //       / \
+            //      3   1
+            //    / | \  \
+            //   1  0  2  0
+            //  /     / \
+            // 0     1   0
+            //      /
+            //     0
+
+            var buffer = new Buffer([ 2,
+                                    /* 0 */ 3,
+                                        /* 0 */ 1,
+                                            /* 0 */ 0,
+                                        /* 1 */ 0,
+                                        /* 2 */ 2,
+                                            /* 0 */ 1,
+                                                /* 0 */ 0,
+                                            /* 1 */ 0,
+                                    /* 1 */ 1,
+                                        /* 0 */ 0 ]);
+            assert.deepEqual(parser.parse(buffer), {
+                length: 2,
+                data: [ {
+                    length: 3,
+                    data: [ { length: 1, data: [ { length: 0, data: [] } ] },
+                            { length: 0, data: [] },
+                            { length: 2, data: [ { length: 1, data: [ { length: 0, data: [] } ] },
+                                                 { length: 0, data: [] } ] } ]
+                }, {
+                    length: 1,
+                    data: [ { length: 0, data: [] } ]
                 } ]
             });
         });
@@ -285,7 +329,7 @@ describe('Composite parser', function(){
             var stop = Parser.start();
 
             var parser =
-                Parser.start().recursiveAs('self')
+                Parser.start().namely('self')
                 .uint8('type')
                 .choice('data', {
                     'tag': 'type',
@@ -301,6 +345,95 @@ describe('Composite parser', function(){
                 data: {
                     type: 1,
                     data: {
+                        type: 1,
+                        data: { type: 0, data: {} }
+                    }
+                }
+            });
+        });
+        it('should be able to go into recursion with simple nesting', function(){
+            var stop = Parser.start();
+
+            var parser =
+                Parser.start().namely('self')
+                .uint8('type')
+                .choice('data', {
+                    'tag': 'type',
+                    'choices': {
+                        0: stop,
+                        1: 'self',
+                        2: Parser.start().nest('left',  { type: 'self' })
+                                         .nest('right', { type: stop })
+                    }
+                });
+
+            var buffer = new Buffer([ 2,
+                                        /* left */  1, 1, 0,
+                                        /* right */ 0 ]);
+            assert.deepEqual(parser.parse(buffer), {
+                type: 2,
+                data: {
+                    left: {
+                        type: 1,
+                        data: { type: 1, data: { type: 0, data: {} } },
+                    },
+                    right: { }
+                }
+            });
+        });
+        it('should be able to go into recursion with complex nesting', function(){
+            var stop = Parser.start();
+
+            var parser =
+                Parser.start().namely('self')
+                .uint8('type')
+                .choice('data', {
+                    'tag': 'type',
+                    'choices': {
+                        0: stop,
+                        1: 'self',
+                        2: Parser.start().nest('left',  { type: 'self' })
+                                         .nest('right', { type: 'self' }),
+                        3: Parser.start().nest('one',   { type: 'self' })
+                                         .nest('two',   { type: 'self' })
+                                         .nest('three', { type: 'self' })
+                    }
+                });
+
+            //        2
+            //       / \
+            //      3   1
+            //    / | \  \
+            //   1  0  2  0
+            //  /     / \
+            // 0     1   0
+            //      /
+            //     0
+
+            var buffer = new Buffer([ 2,
+                                    /* left -> */ 3,
+                                        /* one   -> */ 1, /* -> */ 0,
+                                        /* two   -> */ 0,
+                                        /* three -> */ 2,
+                                            /* left  -> */ 1, /* -> */ 0,
+                                            /* right -> */ 0,
+                                    /* right -> */ 1, /* -> */ 0 ]);
+            assert.deepEqual(parser.parse(buffer), {
+                type: 2,
+                data: {
+                    left: {
+                        type: 3,
+                        data: {
+                            one: { type: 1, data: { type: 0, data: {} } },
+                            two: { type: 0, data: {} },
+                            three: { type: 2,
+                                     data: {
+                                        left: { type: 1, data: { type: 0, data: {} } },
+                                        right: { type: 0, data: {} }
+                                     } },
+                        }
+                    },
+                    right: {
                         type: 1,
                         data: { type: 0, data: {} }
                     }

--- a/test/composite_parser.js
+++ b/test/composite_parser.js
@@ -381,6 +381,40 @@ describe('Composite parser', function(){
                 }
             });
         });
+        it('should be able to refer to other parsers by name', function(){
+            var parser = Parser.start().namely('self');
+
+            var stop = Parser.start().namely('stop');
+
+            var twoCells = Parser.start().namely('twoCells')
+                                         .nest('left',  { type: 'self' })
+                                         .nest('right', { type: 'stop' })
+
+            parser
+                .uint8('type')
+                .choice('data', {
+                    'tag': 'type',
+                    'choices': {
+                        0: 'stop',
+                        1: 'self',
+                        2: 'twoCells'
+                    }
+                });
+
+            var buffer = new Buffer([ 2,
+                                        /* left */  1, 1, 0,
+                                        /* right */ 0 ]);
+            assert.deepEqual(parser.parse(buffer), {
+                type: 2,
+                data: {
+                    left: {
+                        type: 1,
+                        data: { type: 1, data: { type: 0, data: {} } },
+                    },
+                    right: { }
+                }
+            });
+        });
         it('should be able to go into recursion with complex nesting', function(){
             var stop = Parser.start();
 


### PR DESCRIPTION
Introduces a method `.namely(alias)`, which allows user to refer to any parser by name in `.array`, `.choice` and `.nest` methods.

Using this approach, user may reference the parser itself and so be able to parse recursive trees of data:

``` javascript
var stop = Parser.start();

var parser =
    Parser.start().namely('self')
        .uint8('type')
        .choice('data', {
            'tag': 'type',
            'choices': {
                0: stop,
                1: 'self',
                2: Parser.start().nest('left',  { type: 'self' })
                                 .nest('right', { type: 'self' }),
                3: Parser.start().nest('one',   { type: 'self' })
                                 .nest('two',   { type: 'self' })
                                 .nest('three', { type: 'self' })
            }
        });

//        2
//       / \
//      3   1
//    / | \  \
//   1  0  2  0
//  /     / \
// 0     1   0
//      /
//     0

var buffer = new Buffer([ 
    2,
    /* left -> */ 3,
        /* one   -> */ 1, /* -> */ 0,
        /* two   -> */ 0,
        /* three -> */ 2,
            /* left  -> */ 1, /* -> */ 0,
            /* right -> */ 0,
    /* right -> */ 1, /* -> */ 0 ]);

assert.deepEqual(parser.parse(buffer), {
    type: 2,
    data: {
        left: {
            type: 3,
            data: {
                one: { type: 1, data: { type: 0, data: {} } },
                two: { type: 0, data: {} },
                three: { type: 2,
                    data: {
                        left: { type: 1, data: { type: 0, data: {} } },
                        right: { type: 0, data: {} }
                    } 
                },
            }
        },
        right: {
            type: 1,
            data: { type: 0, data: {} }
        }
    }
});
```

See tests for other examples and combinations.

If some parser has an alias, its code is generated in a different way — code is wrapped in a function which is then called for every case of such reference.
