### PR TITLE
Allow Parent parser attributes in choice

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -31,6 +31,9 @@ var SPECIAL_TYPES = {
     'Bit'      : null
 };
 
+var aliasRegistry = {};
+var FUNCTION_PREFIX = '___parser_';
+
 var BIT_RANGE = [];
 (function() {
     var i;
@@ -64,6 +67,7 @@ var Parser = function() {
     this.compiled = null;
     this.endian = 'be';
     this.constructorFn = null;
+    this.alias = null;
 };
 
 //----------------------------------------------------------------------------------------
@@ -97,6 +101,12 @@ BIT_RANGE.forEach(function(i) {
         return this.setNextParser('bit', varName, options);
     };
 });
+
+Parser.prototype.namely = function(alias) {
+    aliasRegistry[alias] = this;
+    this.alias = alias;
+    return this;
+}
 
 Parser.prototype.skip = function(length, options) {
     if (options && options.assert) {
@@ -133,7 +143,8 @@ Parser.prototype.array = function(varName, options) {
     if (!options.type) {
         throw new Error('Type option of array is not defined.');
     }
-    if (typeof options.type === 'string' && Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.type]) < 0) {
+    if ((typeof options.type === 'string') && !aliasRegistry[options.type]
+        && Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.type]) < 0) {
         throw new Error('Specified primitive type "' + options.type + '" is not supported.');
     }
 
@@ -155,10 +166,11 @@ Parser.prototype.choice = function(varName, options) {
             throw new Error('Choice Case ' + key + ' of ' + varName + ' is not valid.');
         }
 
-        if (typeof options.choices[key] === 'string' && Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.choices[key]]) < 0) {
+        if ((typeof options.choices[key] === 'string') && !aliasRegistry[options.choices[key]]
+            && (Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.choices[key]]) < 0)) {
             throw new Error('Specified primitive type "' +  options.choices[key] + '" is not supported.');
         }
-    });
+    }, this);
 
     return this.setNextParser('choice', varName, options);
 };
@@ -167,7 +179,8 @@ Parser.prototype.nest = function(varName, options) {
     if (!options.type) {
         throw new Error('Type option of nest is not defined.');
     }
-    if (!(options.type instanceof Parser)) {
+
+    if (!(options.type instanceof Parser) && !aliasRegistry[options.type]) {
         throw new Error('Type option of nest must be a Parser object.');
     }
 
@@ -202,21 +215,68 @@ Parser.prototype.create = function(constructorFn) {
 Parser.prototype.getCode = function() {
     var ctx = new Context();
 
+    ctx.pushCode('if (!Buffer.isBuffer(buffer)) {');
+    ctx.generateError('"argument buffer is not a Buffer object"');
+    ctx.pushCode('}');
+
+    if (!this.alias) {
+        this.addRawCode(ctx);
+    } else {
+        this.addAliasedCode(ctx);
+    }
+
+    if (this.alias) {
+        ctx.pushCode('return {0}(0).result;', FUNCTION_PREFIX + this.alias);
+    } else {
+        ctx.pushCode('return vars;');
+    }
+
+    return ctx.code;
+};
+
+Parser.prototype.addRawCode = function(ctx) {
+    ctx.pushCode('var offset = 0;');
+
     if (this.constructorFn) {
         ctx.pushCode('var vars = new constructorFn();');
     } else {
         ctx.pushCode('var vars = {};');
     }
-    ctx.pushCode('var offset = 0;');
-    ctx.pushCode('if (!Buffer.isBuffer(buffer)) {');
-    ctx.generateError('"argument buffer is not a Buffer object"');
-    ctx.pushCode('}');
 
     this.generate(ctx);
 
-    ctx.pushCode('return vars;');
+    this.resolveReferences(ctx);
 
-    return ctx.code;
+    ctx.pushCode('return vars;');
+};
+
+Parser.prototype.addAliasedCode = function(ctx) {
+    ctx.pushCode('function {0}(offset) {', FUNCTION_PREFIX + this.alias);
+
+    if (this.constructorFn) {
+        ctx.pushCode('var vars = new constructorFn();');
+    } else {
+        ctx.pushCode('var vars = {};');
+    }
+
+    this.generate(ctx);
+
+    ctx.markResolved(this.alias);
+    this.resolveReferences(ctx);
+
+    ctx.pushCode('return { offset: offset, result: vars };');
+    ctx.pushCode('}');
+
+    return ctx;
+};
+
+Parser.prototype.resolveReferences = function(ctx) {
+    var references = ctx.getUnresolvedReferences();
+    ctx.markRequested(references);
+    references.forEach(function(alias) {
+        var parser = aliasRegistry[alias];
+        parser.addAliasedCode(ctx);
+    });
 };
 
 Parser.prototype.compile = function() {
@@ -482,8 +542,15 @@ Parser.prototype.generateArray = function(ctx) {
     }
 
     if (typeof type === 'string') {
-        ctx.pushCode('var {0} = buffer.read{1}(offset);', item, NAME_MAP[type]);
-        ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+        if (!aliasRegistry[type]) {
+            ctx.pushCode('var {0} = buffer.read{1}(offset);', item, NAME_MAP[type]);
+            ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+        } else {
+            var tempVar = ctx.generateTmpVariable();
+            ctx.pushCode('var {0} = {1}(offset);', tempVar, FUNCTION_PREFIX + type);
+            ctx.pushCode('var {0} = {1}.result; offset = {1}.offset;', item, tempVar);
+            if (type !== this.alias) ctx.addReference(type);
+        }
     } else if (type instanceof Parser) {
         ctx.pushCode('var {0} = {};', item);
 
@@ -507,8 +574,15 @@ Parser.prototype.generateArray = function(ctx) {
 
 Parser.prototype.generateChoiceCase = function(ctx, varName, type) {
     if (typeof type === 'string') {
-        ctx.pushCode('{0} = buffer.read{1}(offset);', ctx.generateVariable(this.varName), NAME_MAP[type]);
-        ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+        if (!aliasRegistry[type]) {
+            ctx.pushCode('{0} = buffer.read{1}(offset);', ctx.generateVariable(this.varName), NAME_MAP[type]);
+            ctx.pushCode('offset += {0};', PRIMITIVE_TYPES[NAME_MAP[type]]);
+        } else {
+            var tempVar = ctx.generateTmpVariable();
+            ctx.pushCode('var {0} = {1}(offset);', tempVar, FUNCTION_PREFIX + type);
+            ctx.pushCode('{0} = {1}.result; offset = {1}.offset;', ctx.generateVariable(this.varName), tempVar);
+            if (type !== this.alias) ctx.addReference(type);
+        }
     } else if (type instanceof Parser) {
         ctx.pushPath(varName);
         type.generate(ctx);
@@ -539,10 +613,17 @@ Parser.prototype.generateChoice = function(ctx) {
 
 Parser.prototype.generateNest = function(ctx) {
     var nestVar = ctx.generateVariable(this.varName);
-    ctx.pushCode('{0} = {};', nestVar);
-    ctx.pushPath(this.varName);
-    this.options.type.generate(ctx);
-    ctx.popPath();
+    if (this.options.type instanceof Parser) {
+        ctx.pushCode('{0} = {};', nestVar);
+        ctx.pushPath(this.varName);
+        this.options.type.generate(ctx);
+        ctx.popPath();
+    } else if (aliasRegistry[this.options.type]) {
+        var tempVar = ctx.generateTmpVariable();
+        ctx.pushCode('var {0} = {1}(offset);', tempVar, FUNCTION_PREFIX + this.options.type);
+        ctx.pushCode('{0} = {1}.result; offset = {1}.offset;', nestVar, tempVar);
+        if (this.options.type !== this.alias) ctx.addReference(this.options.type);
+    }
 };
 
 Parser.prototype.generateFormatter = function(ctx, varName, formatter) {

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -586,14 +586,16 @@ Parser.prototype.generateChoiceCase = function(ctx, varName, type) {
     } else if (type instanceof Parser) {
         ctx.pushPath(varName);
         type.generate(ctx);
-        ctx.popPath();
+        ctx.popPath(varName);
     }
 };
 
 Parser.prototype.generateChoice = function(ctx) {
     var tag = ctx.generateOption(this.options.tag);
-
-    ctx.pushCode('{0} = {};', ctx.generateVariable(this.varName));
+    if (this.varName)
+    {
+        ctx.pushCode('{0} = {};', ctx.generateVariable(this.varName));
+    }
     ctx.pushCode('switch({0}) {', tag);
     Object.keys(this.options.choices).forEach(function(tag) {
         var type = this.options.choices[tag];
@@ -617,7 +619,7 @@ Parser.prototype.generateNest = function(ctx) {
         ctx.pushCode('{0} = {};', nestVar);
         ctx.pushPath(this.varName);
         this.options.type.generate(ctx);
-        ctx.popPath();
+        ctx.popPath(this.varName);
     } else if (aliasRegistry[this.options.type]) {
         var tempVar = ctx.generateTmpVariable();
         ctx.pushCode('var {0} = {1}(offset);', tempVar, FUNCTION_PREFIX + this.options.type);

--- a/lib/context.js
+++ b/lib/context.js
@@ -36,7 +36,7 @@ Context.prototype.generateOption = function(val) {
         case 'string':
             return this.generateVariable(val);
         case 'function':
-            return '(' + val + ').call(' + this.generateVariable() + ')';
+            return '(' + val + ').call(' + this.generateVariable() + ', vars)';
     }
 };
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -12,6 +12,7 @@ var Context = function() {
     this.isAsync = false;
     this.bitFields = [];
     this.tmpVariableCount = 0;
+    this.references = {};
 };
 
 //----------------------------------------------------------------------------------------
@@ -57,7 +58,7 @@ Context.prototype.generateTmpVariable = function() {
 
 Context.prototype.pushCode = function() {
     var args = Array.prototype.slice.call(arguments);
- 
+
     this.code += Context.interpolate.apply(this, args) + '\n';
 };
 
@@ -75,6 +76,28 @@ Context.prototype.pushScope = function(name) {
 
 Context.prototype.popScope = function() {
     this.scopes.pop();
+};
+
+Context.prototype.addReference = function(alias) {
+    if (this.references[alias]) return;
+    this.references[alias] = { resolved: false, requested: false };
+};
+
+Context.prototype.markResolved = function(alias) {
+    this.references[alias].resolved = true;
+};
+
+Context.prototype.markRequested = function(aliasList) {
+    aliasList.forEach(function(alias) {
+        this.references[alias].requested = true;
+    }.bind(this));
+};
+
+Context.prototype.getUnresolvedReferences = function() {
+    var references = this.references;
+    return Object.keys(this.references).filter(function(alias) {
+        return !references[alias].resolved && !references[alias].requested;
+    });
 };
 
 //----------------------------------------------------------------------------------------

--- a/lib/context.js
+++ b/lib/context.js
@@ -63,11 +63,17 @@ Context.prototype.pushCode = function() {
 };
 
 Context.prototype.pushPath = function(name) {
-    this.scopes[this.scopes.length - 1].push(name);
+    if (name)
+    {
+    	this.scopes[this.scopes.length - 1].push(name);
+    }
 };
 
-Context.prototype.popPath = function() {
-    this.scopes[this.scopes.length - 1].pop();
+Context.prototype.popPath = function(name) {
+    if (name)
+   { 
+   	this.scopes[this.scopes.length - 1].pop();
+   }
 };
 
 Context.prototype.pushScope = function(name) {


### PR DESCRIPTION
#42 - Fixes issue allowing a function to access parent parsers attribute values. @keichi 

example usage:
```javascript
.choice('NestedChildChoice', {
        tag:function(all_vars) {
    return all_vars.ParentParser.version;
}
```