### PR TITLE
Add Atom Loophole to use "safer" version of eval

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -4,6 +4,8 @@
 
 var Context = require("./context").Context;
 
+var Function = require("loophole").Function;
+
 var PRIMITIVE_TYPES = {
     'UInt8'    : 1,
     'UInt16LE' : 2,

--- a/package.json
+++ b/package.json
@@ -31,5 +31,7 @@
     "url": "http://github.com/Keichi/binary-parser.git"
   },
   "bugs": "http://github.com/Keichi/binary-parser/issues",
-  "dependencies": {}
+  "dependencies": {
+    "loophole": "^1.1.0"
+  }
 }


### PR DESCRIPTION
Eval is used in `binary-parser` indirectly, with `new Function(...)` call. Using the `loophole` package allows considering it half-safe (and use package with Atom and in other strict places).