### PR TITLE
Fix for issue #45, the buffer parser eof option now works

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -439,7 +439,7 @@ Parser.prototype.generateString = function(ctx) {
 
 Parser.prototype.generateBuffer = function(ctx) {
     if (this.options.readUntil === 'eof') {
-        ctx.pushCode('{0} = buffer.slice(offset, buffer.length - 1);',
+        ctx.pushCode('{0} = buffer.slice(offset);',
             ctx.generateVariable(this.varName)
             );
     } else {

--- a/test/composite_parser.js
+++ b/test/composite_parser.js
@@ -314,6 +314,25 @@ describe('Composite parser', function(){
         });
     });
 
+    describe('Buffer parser', function() {
+            //this is a test for testing a fix of a bug, that removed the last byte of the 
+            //buffer parser
+            it('should return a buffer with same size', function() {
+                
+                var bufferParser = new Parser()
+                    .buffer('buf', {
+                        readUntil: 'eof',
+                        formatter: function(buffer) { 
+                            return buffer;
+                        }
+                    })
+
+                var buffer = new Buffer('John\0Doe\0');
+                assert.deepEqual(bufferParser.parse(buffer),{buf:buffer});
+            });
+    });
+
+
     describe('Constructors', function() {
         it('should create a custom object type', function() {
            function Person () {


### PR DESCRIPTION
the buffer parser with 'eof' as readUntil option didn't work correctly, the slice of the buffer returned was to short, now it works