### PR TITLE
Flattened data stucture for "choice" types

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -166,7 +166,7 @@ Parser.prototype.array = function(varName, options) {
 };
 
 Parser.prototype.choice = function(varName, options) {
-  if (arguments.length == 1 && typeof varName === 'object') {
+  if (arguments.length == 1 && typeof varName === "object") {
     options = varName;
     varName = null;
   }

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -166,6 +166,10 @@ Parser.prototype.array = function(varName, options) {
 };
 
 Parser.prototype.choice = function(varName, options) {
+  if (arguments.length == 1 && typeof varName === 'object') {
+    options = varName;
+    varName = null;
+  }
   if (!options.tag) {
     throw new Error("Tag option of array is not defined.");
   }

--- a/test/composite_parser.js
+++ b/test/composite_parser.js
@@ -784,7 +784,7 @@ describe("Composite parser", function() {
     });
     it("should be able to use function as the choice selector", function() {
       var parser = Parser.start()
-        .string("selector", {length: 4})
+        .string("selector", { length: 4 })
         .choice(null, {
           tag: function() {
             return parseInt(this.selector, 2); // string base 2 to integer decimal
@@ -798,7 +798,10 @@ describe("Composite parser", function() {
         });
 
       var buffer = Buffer.from([
-        48, 48, 49, 48,
+        48,
+        48,
+        49,
+        48,
         0xc,
         0x68,
         0x65,
@@ -814,7 +817,7 @@ describe("Composite parser", function() {
         0x64
       ]);
       assert.deepEqual(parser.parse(buffer), {
-        selector: "0010",  // -> choice 2
+        selector: "0010", // -> choice 2
         length: 12,
         message: "hello, world"
       });

--- a/test/composite_parser.js
+++ b/test/composite_parser.js
@@ -702,6 +702,128 @@ describe("Composite parser", function() {
         }
       });
     });
+    it("should be able to 'flatten' choices when using null varName", function() {
+      var parser = Parser.start()
+        .uint8("tag")
+        .choice(null, {
+          tag: "tag",
+          choices: {
+            1: Parser.start()
+              .uint8("length")
+              .string("message", { length: "length" }),
+            3: Parser.start().int32le("number")
+          }
+        });
+
+      var buffer = Buffer.from([
+        0x1,
+        0xc,
+        0x68,
+        0x65,
+        0x6c,
+        0x6c,
+        0x6f,
+        0x2c,
+        0x20,
+        0x77,
+        0x6f,
+        0x72,
+        0x6c,
+        0x64
+      ]);
+      assert.deepEqual(parser.parse(buffer), {
+        tag: 1,
+        length: 12,
+        message: "hello, world"
+      });
+      buffer = Buffer.from([0x03, 0x4e, 0x61, 0xbc, 0x00]);
+      assert.deepEqual(parser.parse(buffer), {
+        tag: 3,
+        number: 12345678
+      });
+    });
+    it("should be able to 'flatten' choices when omitting varName paramater", function() {
+      var parser = Parser.start()
+        .uint8("tag")
+        .choice({
+          tag: "tag",
+          choices: {
+            1: Parser.start()
+              .uint8("length")
+              .string("message", { length: "length" }),
+            3: Parser.start().int32le("number")
+          }
+        });
+
+      var buffer = Buffer.from([
+        0x1,
+        0xc,
+        0x68,
+        0x65,
+        0x6c,
+        0x6c,
+        0x6f,
+        0x2c,
+        0x20,
+        0x77,
+        0x6f,
+        0x72,
+        0x6c,
+        0x64
+      ]);
+      assert.deepEqual(parser.parse(buffer), {
+        tag: 1,
+        length: 12,
+        message: "hello, world"
+      });
+      buffer = Buffer.from([0x03, 0x4e, 0x61, 0xbc, 0x00]);
+      assert.deepEqual(parser.parse(buffer), {
+        tag: 3,
+        number: 12345678
+      });
+    });
+    it("should be able to use function as the choice selector", function() {
+      var parser = Parser.start()
+        .string("selector", {length: 4})
+        .choice(null, {
+          tag: function() {
+            return parseInt(this.selector, 2); // string base 2 to integer decimal
+          },
+          choices: {
+            2: Parser.start()
+              .uint8("length")
+              .string("message", { length: "length" }),
+            7: Parser.start().int32le("number")
+          }
+        });
+
+      var buffer = Buffer.from([
+        48, 48, 49, 48,
+        0xc,
+        0x68,
+        0x65,
+        0x6c,
+        0x6c,
+        0x6f,
+        0x2c,
+        0x20,
+        0x77,
+        0x6f,
+        0x72,
+        0x6c,
+        0x64
+      ]);
+      assert.deepEqual(parser.parse(buffer), {
+        selector: "0010",  // -> choice 2
+        length: 12,
+        message: "hello, world"
+      });
+      buffer = Buffer.from([48, 49, 49, 49, 0x4e, 0x61, 0xbc, 0x00]);
+      assert.deepEqual(parser.parse(buffer), {
+        selector: "0111", // -> choice 7
+        number: 12345678
+      });
+    });
   });
 
   describe("Nest parser", function() {


### PR DESCRIPTION
Hi,

A wanted to submit a PR to allow to flatten data structure generated by `choice` type parser items, but when looking at the code I figured out that the current code already allow such a feature when you provide *null* or *empty* string as the `name` parameter of the `choice` method.

e.g.: the following Parser:
```
var parser = Parser.start()
    .uint8("tag")
    .choice(null, {    // <- Note the null name here
        tag: "tag",
        choices: {
            1: Parser.start()
              .uint8("length")
              .string("message", { length: "length" }),
            3: Parser.start().int32le("number")
        }
       });
```
would produce parsed object like:
```
{
  tag: 1,
  length: 12,
  message: "hello, world"
}
```
or 
```
{
  tag: 3,
  number: 12345678
}
```
(Note the flat structure of the objects even with the use of a `choice`)

So this pull request only allow to let the `name` parameter of `choice` to be optional (no need to pass null in this case).

The API then becomes:

**choice([name ,]options)**

I have also added 3 unit tests to verify this type of feature.

If you accept this PR, you will probably also have to document this feature in the Readme.

B.R.

--
Eric






