### PR TITLE
Method to get the current offset in buffer when parsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,29 @@ executed for the first time.
 Dynamically generates the code for this parser and returns it as a string.
 Usually used for debugging.
 
+### Internal utilities
+
+### sizeOf()
+Get the *static* size of the parser definition. id some parser items are of type
+"string", "array", or "buffer", size can only be determined when using *number*
+as length option. If not it will return *NaN*
+
+### getLastOffset()
+Get the number of parsed bytes. This function can only be called after parsingin some buffer.
+
+```javascript
+var parser = Parser.start()
+    .uint8("b1")
+    .uint8("b2");
+
+var buffer = Buffer.from([1, 2, 3, 4, 5]);
+
+parser.parse(buffer);  // { b1: 1, b2: 2 }
+parser.getLastOffset(); // 2
+parser.parse(buffer.slice(parser.getLastOffset())); //  { b1: 3, b2: 4 }
+```
+
+
 ### Common options
 These are common options that can be specified in all parsers.
 

--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -69,6 +69,7 @@ var Parser = function() {
   this.endian = "be";
   this.constructorFn = null;
   this.alias = null;
+  this.lastOffset = 0;
 };
 
 //----------------------------------------------------------------------------------------
@@ -250,6 +251,10 @@ Parser.prototype.create = function(constructorFn) {
   return this;
 };
 
+Parser.prototype.getLastOffset = function() {
+  return this.lastOffset;
+};
+
 Parser.prototype.getCode = function() {
   var ctx = new Context();
 
@@ -264,9 +269,11 @@ Parser.prototype.getCode = function() {
   }
 
   if (this.alias) {
-    ctx.pushCode("return {0}(0).result;", FUNCTION_PREFIX + this.alias);
+    var tempVar = ctx.generateTmpVariable();
+    ctx.pushCode("var {0} = {1}(0);", tempVar, FUNCTION_PREFIX + this.alias);
+    ctx.pushCode("return { offset: {0}.offset, vars:{0}.vars };", tempVar);
   } else {
-    ctx.pushCode("return vars;");
+    ctx.pushCode("return { offset: offset, vars:vars };");
   }
 
   return ctx.code;
@@ -285,7 +292,7 @@ Parser.prototype.addRawCode = function(ctx) {
 
   this.resolveReferences(ctx);
 
-  ctx.pushCode("return vars;");
+  ctx.pushCode("return { offset: offset, vars:vars };");
 };
 
 Parser.prototype.addAliasedCode = function(ctx) {
@@ -302,7 +309,7 @@ Parser.prototype.addAliasedCode = function(ctx) {
   ctx.markResolved(this.alias);
   this.resolveReferences(ctx);
 
-  ctx.pushCode("return { offset: offset, result: vars };");
+  ctx.pushCode("return { offset: offset, vars: vars };");
   ctx.pushCode("}");
 
   return ctx;
@@ -376,7 +383,9 @@ Parser.prototype.parse = function(buffer) {
     this.compile();
   }
 
-  return this.compiled(buffer, this.constructorFn);
+  var result = this.compiled(buffer, this.constructorFn);
+  this.lastOffset = result.offset;
+  return result.vars;
 };
 
 //----------------------------------------------------------------------------------------
@@ -584,6 +593,7 @@ Parser.prototype.generateBuffer = function(ctx) {
       "{0} = buffer.slice(offset);",
       ctx.generateVariable(this.varName)
     );
+    ctx.pushCode("offset = buffer.length;");
   } else {
     ctx.pushCode(
       "{0} = buffer.slice(offset, offset + {1});",
@@ -634,7 +644,7 @@ Parser.prototype.generateArray = function(ctx) {
     } else {
       var tempVar = ctx.generateTmpVariable();
       ctx.pushCode("var {0} = {1}(offset);", tempVar, FUNCTION_PREFIX + type);
-      ctx.pushCode("var {0} = {1}.result; offset = {1}.offset;", item, tempVar);
+      ctx.pushCode("var {0} = {1}.vars; offset = {1}.offset;", item, tempVar);
       if (type !== this.alias) ctx.addReference(type);
     }
   } else if (type instanceof Parser) {
@@ -675,7 +685,7 @@ Parser.prototype.generateChoiceCase = function(ctx, varName, type) {
       var tempVar = ctx.generateTmpVariable();
       ctx.pushCode("var {0} = {1}(offset);", tempVar, FUNCTION_PREFIX + type);
       ctx.pushCode(
-        "{0} = {1}.result; offset = {1}.offset;",
+        "{0} = {1}.vars; offset = {1}.offset;",
         ctx.generateVariable(this.varName),
         tempVar
       );
@@ -727,7 +737,7 @@ Parser.prototype.generateNest = function(ctx) {
       tempVar,
       FUNCTION_PREFIX + this.options.type
     );
-    ctx.pushCode("{0} = {1}.result; offset = {1}.offset;", nestVar, tempVar);
+    ctx.pushCode("{0} = {1}.vars; offset = {1}.offset;", nestVar, tempVar);
     if (this.options.type !== this.alias) ctx.addReference(this.options.type);
   }
 };


### PR DESCRIPTION
Hello,

Whereas the un-documented **sizeOf()** method allows to get the size of what a *static* parser will consume.

Here is an implementation of a new **getLastOffset()** method that returns the effective size of parsed data from input buffer.

One possible usage for this method is to partially parse binary data from a buffer and then continue parsing starting where the last parse() stopped.

 ```javascript
var parser = Parser.start()
    .uint8("b1")
    .uint8("b2");

var buffer = Buffer.from([1, 2, 3, 4, 5]);

parser.parse(buffer);  // { b1: 1, b2: 2 }
parser.getLastOffset(); // 2
parser.parse(buffer.slice(parser.getLastOffset())); //  { b1: 3, b2: 4 }
```

The previous example could be done using the **sizeOf()** method, but when using real life parser (with *zeroTerminated* string or using function as length option), this is the only way to determine where the **parse(buffer)** method has stopped.

I have also added some unit tests for this new method and updated the Readme.md

--
Eric