### PR TITLE
Fix of bug #60

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -3,7 +3,7 @@
 //========================================================================================
 var vm = require("vm");
 
-var Buffer = require("buffer").Buffer;
+var Buffer = require("buffer/").Buffer;
 
 var Context = require("./context").Context;
 


### PR DESCRIPTION
https://github.com/keichi/binary-parser/issues/60

I simply inject Buffer into the vm context, as this one could be missing in few configurations (angular + webpack for instance)