### PR TITLE
JPG example should use assert, not validate

### DIFF
--- a/example/jpg.js
+++ b/example/jpg.js
@@ -10,7 +10,7 @@ var APP0 = Parser.start()
   .string("id", {
     encoding: "ascii",
     zeroTerminated: true,
-    validate: "JFIF"
+    assert: "JFIF"
   })
   .uint16("version")
   .uint8("unit")


### PR DESCRIPTION
Was "assert" called "validate" in an older version? Can't find any use or definition of "validate" in the current one.