### PR TITLE
fix Buffer not defined when running in some browser environments

### DIFF
--- a/lib/binary_parser.js
+++ b/lib/binary_parser.js
@@ -5,6 +5,9 @@ var vm = require("vm");
 
 var Context = require("./context").Context;
 
+if (typeof window !== 'undefined')
+  window.Buffer = Buffer
+
 var PRIMITIVE_TYPES = {
   UInt8: 1,
   UInt16LE: 2,

--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
   "devDependencies": {
     "istanbul": "^0.4.5",
     "mocha": "^3.5.3",
-    "prettier": "^1.9.2"
+    "opn-cli": "^3.1.0",
+    "prettier": "^1.9.2",
+    "webpack": "^4.6.0",
+    "webpack-cli": "^2.0.15"
   },
   "scripts": {
     "fmt": "npx prettier --write '{lib,test,example}/**/*.js'",
     "check-fmt": "npx prettier --list-different '{lib,test,example}/**/*.js'",
     "test": "npx mocha --reporter spec",
-    "cover": "npx istanbul cover --report html node_modules/.bin/_mocha"
+    "cover": "npx istanbul cover --report html node_modules/.bin/_mocha",
+    "test-webpack": "npx webpack --config test/browser/webpack.config.js && opn test/browser/run-mocha.html"
   },
   "keywords": [
     "binary",
@@ -36,6 +40,6 @@
   "bugs": "http://github.com/keichi/binary-parser/issues",
   "dependencies": {},
   "engines": {
-      "node": ">=5.10.0"
+    "node": ">=5.10.0"
   }
 }

--- a/test/browser/.gitignore
+++ b/test/browser/.gitignore
@@ -1,0 +1,1 @@
+bundle.js*

--- a/test/browser/entry.js
+++ b/test/browser/entry.js
@@ -1,0 +1,2 @@
+require('../primitive_parser')
+require('../composite_parser')

--- a/test/browser/run-mocha.html
+++ b/test/browser/run-mocha.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Mocha Tests</title>
+  <link href="../../node_modules/mocha/mocha.css" rel="stylesheet" />
+</head>
+<body>
+  <div id="mocha"></div>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script>mocha.setup('bdd')</script>
+  <script src="bundle.js"></script>
+  <script>
+    mocha.fullTrace();
+    //mocha.checkLeaks();
+    mocha.run();
+  </script>
+</body>
+</html>

--- a/test/browser/webpack.config.js
+++ b/test/browser/webpack.config.js
@@ -1,0 +1,10 @@
+const path = require('path')
+
+module.exports = {
+  entry: path.resolve(__dirname, 'entry.js'),
+  output: {
+    path: __dirname,
+    filename: 'bundle.js',
+  },
+  mode: 'development',
+}


### PR DESCRIPTION
Also adds a small webpack-based test runner to run the mocha tests in whatever the default browser is. Run `npm run test-webpack` to run it.

I think this probably fixes #60 