### PR TITLE
Fix module not found error when running the examples

### DIFF
--- a/example/bmp.js
+++ b/example/bmp.js
@@ -1,4 +1,4 @@
-var Parser = require('../lib/binary_parser.js').Parser;
+var Parser = require('../dist/binary_parser').Parser;
 
 // C structure BITMAPFILEHEADER
 // typedef struct tagBITMAPFILEHEADER {

--- a/example/classfile.js
+++ b/example/classfile.js
@@ -1,4 +1,4 @@
-var Parser = require('../lib/binary_parser').Parser;
+var Parser = require('../dist/binary_parser').Parser;
 
 var ConstantClassInfo = Parser.start().uint16be('name_index');
 

--- a/example/ip.js
+++ b/example/ip.js
@@ -1,4 +1,4 @@
-var Parser = require('../lib/binary_parser').Parser;
+var Parser = require('../dist/binary_parser').Parser;
 
 var ipHeader = new Parser()
   .endianess('big')

--- a/example/jpg.js
+++ b/example/jpg.js
@@ -1,4 +1,4 @@
-var Parser = require('../lib/binary_parser').Parser;
+var Parser = require('../dist/binary_parser').Parser;
 
 var SOI = Parser.start();
 

--- a/example/mbr.js
+++ b/example/mbr.js
@@ -1,4 +1,4 @@
-var Parser = require('../lib/binary_parser.js').Parser;
+var Parser = require('../dist/binary_parser').Parser;
 var fs = require('fs');
 
 var chs = new Parser({

--- a/example/tar.js
+++ b/example/tar.js
@@ -1,4 +1,4 @@
-var Parser = require('../lib/binary_parser.js').Parser;
+var Parser = require('../dist/binary_parser').Parser;
 var fs = require('fs');
 
 var oct2int = function(s) {

--- a/example/tcp.js
+++ b/example/tcp.js
@@ -1,4 +1,4 @@
-var Parser = require('../lib/binary_parser').Parser;
+var Parser = require('../dist/binary_parser').Parser;
 
 var tcpHeader = new Parser()
   .endianess('big')


### PR DESCRIPTION
```
internal/modules/cjs/loader.js:626
    throw err;
    ^

Error: Cannot find module '../lib/binary_parser'
Require stack:
- /Users/keichi/Projects/private/binary-parser/example/tcp.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:623:15)
    at Function.Module._load (internal/modules/cjs/loader.js:527:27)
    at Module.require (internal/modules/cjs/loader.js:681:19)
    at require (internal/modules/cjs/helpers.js:16:16)
    at Object.<anonymous> (/Users/keichi/Projects/private/binary-parser/example/tcp.js:1:14)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/keichi/Projects/private/binary-parser/example/tcp.js' ]
}
```