### PR TITLE
Remove dynamic calls to generateXX()

### DIFF
--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -423,7 +423,7 @@ export class Parser {
       Object.keys(PRIMITIVES_SIZES).indexOf(NAME_MAP[options.type]) < 0
     ) {
       throw new Error(
-        'Specified primitive type "' + options.type + '" is not supported.'
+          `Specified primitive type "${options.type}" is not supported.`
       );
     }
 
@@ -448,9 +448,7 @@ export class Parser {
         throw new Error('Key of choices must be a number.');
       }
       if (!options.choices[key]) {
-        throw new Error(
-          'Choice Case ' + key + ' of ' + varName + ' is not valid.'
-        );
+        throw new Error(`Choice Case ${key} of ${varName} is not valid.`);
       }
 
       if (
@@ -459,9 +457,7 @@ export class Parser {
         Object.keys(PRIMITIVES_SIZES).indexOf(NAME_MAP[options.choices[key]]) < 0
       ) {
         throw new Error(
-          'Specified primitive type "' +
-            options.choices[key] +
-            '" is not supported.'
+          `Specified primitive type "${options.choices[key]}" is not supported.`
         );
       }
     });
@@ -499,7 +495,7 @@ export class Parser {
         this.endian = 'be';
         break;
       default:
-        throw new Error('Invalid endianess: ' + endianess);
+        throw new Error(`Invalid endianess: ${endianess}`);
     }
 
     return this;

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -423,7 +423,7 @@ export class Parser {
       Object.keys(PRIMITIVES_SIZES).indexOf(NAME_MAP[options.type]) < 0
     ) {
       throw new Error(
-          `Specified primitive type "${options.type}" is not supported.`
+        `Specified primitive type "${options.type}" is not supported.`
       );
     }
 
@@ -454,7 +454,8 @@ export class Parser {
       if (
         typeof options.choices[key] === 'string' &&
         !aliasRegistry[options.choices[key]] &&
-        Object.keys(PRIMITIVES_SIZES).indexOf(NAME_MAP[options.choices[key]]) < 0
+        Object.keys(PRIMITIVES_SIZES).indexOf(NAME_MAP[options.choices[key]]) <
+          0
       ) {
         throw new Error(
           `Specified primitive type "${options.choices[key]}" is not supported.`
@@ -664,45 +665,45 @@ export class Parser {
   // Call code generator for this parser
   private generate(ctx: Context) {
     if (this.type) {
-        switch (this.type) {
-          case 'UInt8':
-          case 'UInt16LE':
-          case 'UInt16BE':
-          case 'UInt32LE':
-          case 'UInt32BE':
-          case 'Int8':
-          case 'Int16LE':
-          case 'Int16BE':
-          case 'Int32LE':
-          case 'Int32BE':
-          case 'FloatLE':
-          case 'FloatBE':
-          case 'DoubleLE':
-          case 'DoubleBE':
-            this.primitiveGenerateN(this.type, ctx);
-            break;
-          case 'Bit':
-            this.generateBit(ctx);
-            break;
-          case 'String':
-            this.generateString(ctx);
-            break;
-          case 'Buffer':
-            this.generateBuffer(ctx);
-            break;
-          case 'Skip':
-            this.generateSkip(ctx);
-            break;
-          case 'Nest':
-            this.generateNest(ctx);
-            break;
-          case 'Array':
-            this.generateArray(ctx);
-            break;
-          case 'Choice':
-            this.generateChoice(ctx);
-            break;
-        }
+      switch (this.type) {
+        case 'UInt8':
+        case 'UInt16LE':
+        case 'UInt16BE':
+        case 'UInt32LE':
+        case 'UInt32BE':
+        case 'Int8':
+        case 'Int16LE':
+        case 'Int16BE':
+        case 'Int32LE':
+        case 'Int32BE':
+        case 'FloatLE':
+        case 'FloatBE':
+        case 'DoubleLE':
+        case 'DoubleBE':
+          this.primitiveGenerateN(this.type, ctx);
+          break;
+        case 'Bit':
+          this.generateBit(ctx);
+          break;
+        case 'String':
+          this.generateString(ctx);
+          break;
+        case 'Buffer':
+          this.generateBuffer(ctx);
+          break;
+        case 'Skip':
+          this.generateSkip(ctx);
+          break;
+        case 'Nest':
+          this.generateNest(ctx);
+          break;
+        case 'Array':
+          this.generateArray(ctx);
+          break;
+        case 'Choice':
+          this.generateChoice(ctx);
+          break;
+      }
       this.generateAssert(ctx);
     }
 

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -38,13 +38,13 @@ const NAME_MAP = {
   floatbe: 'FloatBE',
   doublele: 'DoubleLE',
   doublebe: 'DoubleBE',
-  string: 'String',
-  buffer: 'Buffer',
-  array: 'Array',
-  skip: 'Skip',
-  choice: 'Choice',
-  nest: 'Nest',
-  bit: 'Bit',
+  String: 'String',
+  Buffer: 'Buffer',
+  Array: 'Array',
+  Skip: 'Skip',
+  Choice: 'Choice',
+  Nest: 'Nest',
+  Bit: 'Bit',
 };
 
 interface ParserOptions {
@@ -68,19 +68,29 @@ interface ParserOptions {
 type Types =
   | 'String'
   | 'Buffer'
-  | 'String'
   | 'Skip'
   | 'Nest'
   | 'Array'
-  | 'choice'
-  | 'nest'
-  | 'array'
-  | 'skip'
-  | 'buffer'
-  | 'string'
-  | 'bit'
+  | 'Choice'
+  | 'Bit'
+  | 'UInt8'
+  | 'UInt16LE'
+  | 'UInt16BE'
+  | 'UInt32LE'
+  | 'UInt32BE'
+  | 'Int8'
+  | 'Int16LE'
+  | 'Int16BE'
+  | 'Int32LE'
+  | 'Int32BE'
+  | 'FloatLE'
+  | 'FloatBE'
+  | 'DoubleLE'
+  | 'DoubleBE'
   | '';
+
 type Endianess = 'be' | 'le';
+
 type PrimitiveTypesUppercase =
   | 'UInt8'
   | 'UInt16LE'
@@ -96,6 +106,7 @@ type PrimitiveTypesUppercase =
   | 'FloatBE'
   | 'DoubleLE'
   | 'DoubleBE';
+
 type PrimitiveTypes =
   | 'uint8'
   | 'uint16le'
@@ -111,6 +122,7 @@ type PrimitiveTypes =
   | 'floatbe'
   | 'doublele'
   | 'doublebe';
+
 type PrimitiveTypesWithoutEndian =
   | 'uint8'
   | 'uint16'
@@ -118,6 +130,7 @@ type PrimitiveTypesWithoutEndian =
   | 'int8'
   | 'int16'
   | 'int32';
+
 type BitSizes =
   | 1
   | 2
@@ -176,56 +189,6 @@ export class Parser {
     ctx.pushCode(`offset += ${PRIMITIVE_TYPES[type]};`);
   }
 
-  private generateUInt8(ctx: Context) {
-    this.primitiveGenerateN('UInt8', ctx);
-  }
-
-  private generateUInt16LE(ctx: Context) {
-    this.primitiveGenerateN('UInt16LE', ctx);
-  }
-  private generateUInt16BE(ctx: Context) {
-    this.primitiveGenerateN('UInt16BE', ctx);
-  }
-
-  private generateUInt32LE(ctx: Context) {
-    this.primitiveGenerateN('UInt32LE', ctx);
-  }
-  private generateUInt32BE(ctx: Context) {
-    this.primitiveGenerateN('UInt32BE', ctx);
-  }
-
-  private generateInt8(ctx: Context) {
-    this.primitiveGenerateN('Int8', ctx);
-  }
-
-  private generateInt16LE(ctx: Context) {
-    this.primitiveGenerateN('Int16LE', ctx);
-  }
-  private generateInt16BE(ctx: Context) {
-    this.primitiveGenerateN('Int16BE', ctx);
-  }
-
-  private generateInt32LE(ctx: Context) {
-    this.primitiveGenerateN('Int32LE', ctx);
-  }
-  private generateInt32BE(ctx: Context) {
-    this.primitiveGenerateN('Int32BE', ctx);
-  }
-
-  private generateFloatLE(ctx: Context) {
-    this.primitiveGenerateN('FloatLE', ctx);
-  }
-  private generateFloatBE(ctx: Context) {
-    this.primitiveGenerateN('FloatBE', ctx);
-  }
-
-  private generateDoubleLE(ctx: Context) {
-    this.primitiveGenerateN('DoubleLE', ctx);
-  }
-  private generateDoubleBE(ctx: Context) {
-    this.primitiveGenerateN('DoubleBE', ctx);
-  }
-
   private primitiveN(
     type: PrimitiveTypes,
     varName: string,
@@ -233,9 +196,11 @@ export class Parser {
   ) {
     return this.setNextParser(type as Types, varName, options);
   }
+
   private useThisEndian(type: PrimitiveTypesWithoutEndian): PrimitiveTypes {
     return (type + this.endian.toLowerCase()) as PrimitiveTypes;
   }
+
   uint8(varName: string, options?: ParserOptions) {
     return this.primitiveN('uint8', varName, options);
   }
@@ -303,7 +268,7 @@ export class Parser {
       options = {};
     }
     options.length = size;
-    return this.setNextParser('bit', varName, options);
+    return this.setNextParser('Bit', varName, options);
   }
   bit1(varName: string, options?: ParserOptions) {
     return this.bitN(1, varName, options);
@@ -413,7 +378,7 @@ export class Parser {
       throw new Error('assert option on skip is not allowed.');
     }
 
-    return this.setNextParser('skip', '', { length: length });
+    return this.setNextParser('Skip', '', { length: length });
   }
 
   string(varName: string, options: ParserOptions) {
@@ -434,7 +399,7 @@ export class Parser {
     }
     options.encoding = options.encoding || 'utf8';
 
-    return this.setNextParser('string', varName, options);
+    return this.setNextParser('String', varName, options);
   }
 
   buffer(varName: string, options: ParserOptions) {
@@ -442,7 +407,7 @@ export class Parser {
       throw new Error('Length nor readUntil is defined in buffer parser');
     }
 
-    return this.setNextParser('buffer', varName, options);
+    return this.setNextParser('Buffer', varName, options);
   }
 
   array(varName: string, options: ParserOptions) {
@@ -462,7 +427,7 @@ export class Parser {
       );
     }
 
-    return this.setNextParser('array', varName, options);
+    return this.setNextParser('Array', varName, options);
   }
 
   choice(varName: string | ParserOptions, options?: ParserOptions) {
@@ -501,7 +466,7 @@ export class Parser {
       }
     });
 
-    return this.setNextParser('choice', varName as string, options);
+    return this.setNextParser('Choice', varName as string, options);
   }
 
   nest(varName: string | ParserOptions, options: ParserOptions) {
@@ -522,7 +487,7 @@ export class Parser {
       );
     }
 
-    return this.setNextParser('nest', varName as string, options);
+    return this.setNextParser('Nest', varName as string, options);
   }
 
   endianess(endianess: 'little' | 'big') {
@@ -703,7 +668,45 @@ export class Parser {
   // Call code generator for this parser
   private generate(ctx: Context) {
     if (this.type) {
-      this['generate' + this.type](ctx);
+        switch (this.type) {
+          case 'UInt8':
+          case 'UInt16LE':
+          case 'UInt16BE':
+          case 'UInt32LE':
+          case 'UInt32BE':
+          case 'Int8':
+          case 'Int16LE':
+          case 'Int16BE':
+          case 'Int32LE':
+          case 'Int32BE':
+          case 'FloatLE':
+          case 'FloatBE':
+          case 'DoubleLE':
+          case 'DoubleBE':
+            this.primitiveGenerateN(this.type, ctx);
+            break;
+          case 'Bit':
+            this.generateBit(ctx);
+            break;
+          case 'String':
+            this.generateString(ctx);
+            break;
+          case 'Buffer':
+            this.generateBuffer(ctx);
+            break;
+          case 'Skip':
+            this.generateSkip(ctx);
+            break;
+          case 'Nest':
+            this.generateNest(ctx);
+            break;
+          case 'Array':
+            this.generateArray(ctx);
+            break;
+          case 'Choice':
+            this.generateChoice(ctx);
+            break;
+        }
       this.generateAssert(ctx);
     }
 

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -2,7 +2,7 @@ import { Buffer } from 'buffer';
 import { runInNewContext } from 'vm';
 import { Context } from './context';
 
-const PRIMITIVE_TYPES: { [key in PrimitiveTypesUppercase]: number } = {
+const PRIMITIVES_SIZES: { [key in PrimitiveTypesUppercase]: number } = {
   UInt8: 1,
   UInt16LE: 2,
   UInt16BE: 2,
@@ -186,7 +186,7 @@ export class Parser {
     ctx.pushCode(
       `${ctx.generateVariable(this.varName)} = buffer.read${type}(offset);`
     );
-    ctx.pushCode(`offset += ${PRIMITIVE_TYPES[type]};`);
+    ctx.pushCode(`offset += ${PRIMITIVES_SIZES[type]};`);
   }
 
   private primitiveN(
@@ -420,7 +420,7 @@ export class Parser {
     if (
       typeof options.type === 'string' &&
       !aliasRegistry[options.type] &&
-      Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.type]) < 0
+      Object.keys(PRIMITIVES_SIZES).indexOf(NAME_MAP[options.type]) < 0
     ) {
       throw new Error(
         'Specified primitive type "' + options.type + '" is not supported.'
@@ -456,7 +456,7 @@ export class Parser {
       if (
         typeof options.choices[key] === 'string' &&
         !aliasRegistry[options.choices[key]] &&
-        Object.keys(PRIMITIVE_TYPES).indexOf(NAME_MAP[options.choices[key]]) < 0
+        Object.keys(PRIMITIVES_SIZES).indexOf(NAME_MAP[options.choices[key]]) < 0
       ) {
         throw new Error(
           'Specified primitive type "' +
@@ -590,8 +590,8 @@ export class Parser {
   sizeOf() {
     let size = NaN;
 
-    if (Object.keys(PRIMITIVE_TYPES).indexOf(this.type) >= 0) {
-      size = PRIMITIVE_TYPES[this.type];
+    if (Object.keys(PRIMITIVES_SIZES).indexOf(this.type) >= 0) {
+      size = PRIMITIVES_SIZES[this.type];
 
       // if this is a fixed length string
     } else if (
@@ -614,7 +614,7 @@ export class Parser {
     ) {
       let elementSize = NaN;
       if (typeof this.options.type === 'string') {
-        elementSize = PRIMITIVE_TYPES[NAME_MAP[this.options.type]];
+        elementSize = PRIMITIVES_SIZES[NAME_MAP[this.options.type]];
       } else if (this.options.type instanceof Parser) {
         elementSize = this.options.type.sizeOf();
       }
@@ -903,7 +903,7 @@ export class Parser {
     if (typeof type === 'string') {
       if (!aliasRegistry[type]) {
         ctx.pushCode(`var ${item} = buffer.read${NAME_MAP[type]}(offset);`);
-        ctx.pushCode(`offset += ${PRIMITIVE_TYPES[NAME_MAP[type]]};`);
+        ctx.pushCode(`offset += ${PRIMITIVES_SIZES[NAME_MAP[type]]};`);
       } else {
         const tempVar = ctx.generateTmpVariable();
         ctx.pushCode(`var ${tempVar} = ${FUNCTION_PREFIX + type}(offset);`);
@@ -945,7 +945,7 @@ export class Parser {
       const varName = ctx.generateVariable(this.varName);
       if (!aliasRegistry[type]) {
         ctx.pushCode(`${varName} = buffer.read${NAME_MAP[type]}(offset);`);
-        ctx.pushCode(`offset += ${PRIMITIVE_TYPES[NAME_MAP[type]]}`);
+        ctx.pushCode(`offset += ${PRIMITIVES_SIZES[NAME_MAP[type]]}`);
       } else {
         const tempVar = ctx.generateTmpVariable();
         ctx.pushCode(`var ${tempVar} = ${FUNCTION_PREFIX + type}(offset);`);

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -584,7 +584,7 @@ export class Parser {
     ) {
       let elementSize = NaN;
       if (typeof this.options.type === 'string') {
-          elementSize = PRIMITIVE_SIZES[this.options.type as PrimitiveTypes];
+        elementSize = PRIMITIVE_SIZES[this.options.type as PrimitiveTypes];
       } else if (this.options.type instanceof Parser) {
         elementSize = this.options.type.sizeOf();
       }

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -561,7 +561,7 @@ export class Parser {
     let size = NaN;
 
     if (Object.keys(PRIMITIVE_SIZES).indexOf(this.type) >= 0) {
-      size = PRIMITIVE_SIZES[this.type];
+      size = PRIMITIVE_SIZES[this.type as PrimitiveTypes];
 
       // if this is a fixed length string
     } else if (
@@ -584,7 +584,7 @@ export class Parser {
     ) {
       let elementSize = NaN;
       if (typeof this.options.type === 'string') {
-        elementSize = PRIMITIVE_SIZES[this.options.type];
+          elementSize = PRIMITIVE_SIZES[this.options.type as PrimitiveTypes];
       } else if (this.options.type instanceof Parser) {
         elementSize = this.options.type.sizeOf();
       }
@@ -874,7 +874,7 @@ export class Parser {
       if (!aliasRegistry[type]) {
         const typeName = CAPITILIZED_TYPE_NAMES[type as PrimitiveTypes];
         ctx.pushCode(`var ${item} = buffer.read${typeName}(offset);`);
-        ctx.pushCode(`offset += ${PRIMITIVE_SIZES[type]};`);
+        ctx.pushCode(`offset += ${PRIMITIVE_SIZES[type as PrimitiveTypes]};`);
       } else {
         const tempVar = ctx.generateTmpVariable();
         ctx.pushCode(`var ${tempVar} = ${FUNCTION_PREFIX + type}(offset);`);
@@ -917,7 +917,7 @@ export class Parser {
       if (!aliasRegistry[type]) {
         const typeName = CAPITILIZED_TYPE_NAMES[type as Types];
         ctx.pushCode(`${varName} = buffer.read${typeName}(offset);`);
-        ctx.pushCode(`offset += ${PRIMITIVE_SIZES[type]}`);
+        ctx.pushCode(`offset += ${PRIMITIVE_SIZES[type as PrimitiveTypes]}`);
       } else {
         const tempVar = ctx.generateTmpVariable();
         ctx.pushCode(`var ${tempVar} = ${FUNCTION_PREFIX + type}(offset);`);

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -176,53 +176,53 @@ export class Parser {
     ctx.pushCode(`offset += ${PRIMITIVE_TYPES[type]};`);
   }
 
-  generateUInt8(ctx: Context) {
+  private generateUInt8(ctx: Context) {
     this.primitiveGenerateN('UInt8', ctx);
   }
 
-  generateUInt16LE(ctx: Context) {
+  private generateUInt16LE(ctx: Context) {
     this.primitiveGenerateN('UInt16LE', ctx);
   }
-  generateUInt16BE(ctx: Context) {
+  private generateUInt16BE(ctx: Context) {
     this.primitiveGenerateN('UInt16BE', ctx);
   }
 
-  generateUInt32LE(ctx: Context) {
+  private generateUInt32LE(ctx: Context) {
     this.primitiveGenerateN('UInt32LE', ctx);
   }
-  generateUInt32BE(ctx: Context) {
+  private generateUInt32BE(ctx: Context) {
     this.primitiveGenerateN('UInt32BE', ctx);
   }
 
-  generateInt8(ctx: Context) {
+  private generateInt8(ctx: Context) {
     this.primitiveGenerateN('Int8', ctx);
   }
 
-  generateInt16LE(ctx: Context) {
+  private generateInt16LE(ctx: Context) {
     this.primitiveGenerateN('Int16LE', ctx);
   }
-  generateInt16BE(ctx: Context) {
+  private generateInt16BE(ctx: Context) {
     this.primitiveGenerateN('Int16BE', ctx);
   }
 
-  generateInt32LE(ctx: Context) {
+  private generateInt32LE(ctx: Context) {
     this.primitiveGenerateN('Int32LE', ctx);
   }
-  generateInt32BE(ctx: Context) {
+  private generateInt32BE(ctx: Context) {
     this.primitiveGenerateN('Int32BE', ctx);
   }
 
-  generateFloatLE(ctx: Context) {
+  private generateFloatLE(ctx: Context) {
     this.primitiveGenerateN('FloatLE', ctx);
   }
-  generateFloatBE(ctx: Context) {
+  private generateFloatBE(ctx: Context) {
     this.primitiveGenerateN('FloatBE', ctx);
   }
 
-  generateDoubleLE(ctx: Context) {
+  private generateDoubleLE(ctx: Context) {
     this.primitiveGenerateN('DoubleLE', ctx);
   }
-  generateDoubleBE(ctx: Context) {
+  private generateDoubleBE(ctx: Context) {
     this.primitiveGenerateN('DoubleBE', ctx);
   }
 

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,7 +1,9 @@
+import { Parser } from './binary_parser';
+
 export class Context {
   code = '';
   scopes = [['vars']];
-  bitFields = [];
+  bitFields: Parser[] = [];
   tmpVariableCount = 0;
   references: { [key: string]: { resolved: boolean; requested: boolean } } = {};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,9 +67,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
-      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz",
+      "integrity": "sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==",
       "dev": true
     },
     "@babel/template": {
@@ -84,16 +84,16 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
-      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
+      "integrity": "sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/generator": "^7.4.4",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.4.4",
+        "@babel/parser": "^7.4.5",
         "@babel/types": "^7.4.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
@@ -108,11 +108,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
         }
       }
     },
@@ -193,12 +188,14 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -353,7 +350,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -362,48 +360,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-        }
       }
     },
     "cp-file": {
@@ -417,13 +373,6 @@
         "nested-error-stacks": "^2.0.0",
         "pify": "^4.0.1",
         "safe-buffer": "^5.0.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-        }
       }
     },
     "cross-spawn": {
@@ -613,31 +562,14 @@
             "lru-cache": "^4.0.1",
             "which": "^1.2.9"
           }
-        },
-        "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.2",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU="
         }
       }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -764,6 +696,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -772,7 +705,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "invert-kv": {
       "version": "2.0.0",
@@ -871,9 +805,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
-          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+          "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
           "dev": true
         }
       }
@@ -931,9 +865,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.4.tgz",
-      "integrity": "sha512-QCHGyZEK0bfi9GR215QSm+NJwFKEShbtc7tfbUdLAEzn3kKhLDDZqvljn8rPZM9v8CEOhzL1nlYoO4r1ryl67w==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
       "dev": true,
       "requires": {
         "handlebars": "^4.1.2"
@@ -1094,6 +1028,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1214,9 +1149,9 @@
       "dev": true
     },
     "nyc": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.0.tgz",
-      "integrity": "sha512-iy9fEV8Emevz3z/AanIZsoGa8F4U2p0JKevZ/F0sk+/B2r9E6Qn+EPs0bpxEhnAt6UPlTL8mQZIaSJy8sK0ZFw==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-14.1.1.tgz",
+      "integrity": "sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
@@ -1278,6 +1213,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1382,7 +1318,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
@@ -1429,9 +1366,9 @@
       }
     },
     "prettier": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
-      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.1.tgz",
+      "integrity": "sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==",
       "dev": true
     },
     "pseudomap": {
@@ -1813,12 +1750,13 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
-      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/binary_parser.js",
   "devDependencies": {
     "mocha": "^6.1.4",
-    "nyc": "^14.1.0",
-    "prettier": "^1.9.2",
+    "nyc": "^14.1.1",
+    "prettier": "^1.17.1",
     "@types/node": "^12.0.4",
     "typescript": "^3.5.1"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,19 +24,19 @@
 
     /* Strict Type-Checking Options */
     "strict": false,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    "noUnusedLocals": true,                /* Report errors on unused locals. */
+    "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */


### PR DESCRIPTION
`Parser.generate()` was making calls to the corresponding code generators (`generateXX()`) by their name:

```javascript
this['generate' + this.type](ctx);
```

This PR replaces this with a simple switch-case.