### PR TITLE
add big int 64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,17 @@ compiled on-the-fly and internally cached.
 Set the constructor function that should be called to create the object
 returned from the `parse` method.
 
-### [u]int{8, 16, 32}{le, be}(name[, options])
+### [u]int{8, 16, 32, 64}{le, be}(name[, options])
 Parse bytes as an integer and store it in a variable named `name`. `name`
 should consist only of alphanumeric characters and start with an alphabet.
-Number of bits can be chosen from 8, 16 and 32. Byte-ordering can be either
+Number of bits can be chosen from 8, 16, 32 and 64. Byte-ordering can be either
 `l` for little endian or `b` for big endian. With no prefix, it parses as a
-signed number, with `u` prefixed as an unsigned number.
+signed number, with `u` prefixed as an unsigned number. The runtime type 
+returned by the 8, 16, 32 bit methods is `number` while the type 
+returned by the 64 bit is `bigint`.  
+  
+**NOTE:** [u]int64{be,le} methods only work if your runtime is Nodejs v12.0.0 or 
+greater. Lower version will throw a runtime error.
 
 ```javascript
 var parser = new Parser()
@@ -100,6 +105,8 @@ var parser = new Parser()
   .uint8("b")
   // Signed 16-bit integer (big endian)
   .int16be("c");
+  // signed 64-bit integer (big endian)
+  .int64be("d")
 ```
 
 ### bit\[1-32\](name[, options])

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -43,15 +43,15 @@ type PrimitiveTypes =
   | 'uint16be'
   | 'uint32le'
   | 'uint32be'
+  | 'uint64le'
+  | 'uint64be'
   | 'int8'
   | 'int16le'
   | 'int16be'
   | 'int32le'
   | 'int32be'
-  | 'biguint64le'
-  | 'biguint64be'
-  | 'bigint64le'
-  | 'bigint64be'
+  | 'int64le'
+  | 'int64be'
   | 'floatle'
   | 'floatbe'
   | 'doublele'
@@ -64,8 +64,8 @@ type PrimitiveTypesWithoutEndian =
   | 'int8'
   | 'int16'
   | 'int32'
-  | 'bigint64'
-  | 'biguint64';
+  | 'int64'
+  | 'uint64';
 
 type BitSizes =
   | 1
@@ -112,10 +112,10 @@ const PRIMITIVE_SIZES: { [key in PrimitiveTypes]: number } = {
   int16be: 2,
   int32le: 4,
   int32be: 4,
-  bigint64be: 8,
-  bigint64le: 8,
-  biguint64be: 8,
-  biguint64le: 8,
+  int64be: 8,
+  int64le: 8,
+  uint64be: 8,
+  uint64le: 8,
   floatle: 4,
   floatbe: 4,
   doublele: 8,
@@ -133,10 +133,10 @@ const CAPITILIZED_TYPE_NAMES: { [key in Types]: string } = {
   int16be: 'Int16BE',
   int32le: 'Int32LE',
   int32be: 'Int32BE',
-  bigint64be: 'BigInt64BE',
-  bigint64le: 'BigInt64LE',
-  biguint64be: 'BigUInt64BE',
-  biguint64le: 'BigUInt64LE',
+  int64be: 'BigInt64BE',
+  int64le: 'BigInt64LE',
+  uint64be: 'BigUInt64BE',
+  uint64le: 'BigUInt64LE',
   floatle: 'FloatLE',
   floatbe: 'FloatBE',
   doublele: 'DoubleLE',
@@ -237,7 +237,7 @@ export class Parser {
     return this.primitiveN('int32be', varName, options);
   }
 
-  private bigIntVerCheck() {
+  private bigIntVersionCheck() {
     const [major] = process.version.replace('v', '').split('.');
     if (Number(major) < 12) {
       throw new Error(
@@ -247,30 +247,30 @@ export class Parser {
       );
     }
   }
-  bigint64(varName: string, options?: ParserOptions) {
-    this.bigIntVerCheck();
-    return this.primitiveN(this.useThisEndian('bigint64'), varName, options);
+  int64(varName: string, options?: ParserOptions) {
+    this.bigIntVersionCheck();
+    return this.primitiveN(this.useThisEndian('int64'), varName, options);
   }
-  bigint64be(varName: string, options?: ParserOptions) {
-    this.bigIntVerCheck();
-    return this.primitiveN('bigint64be', varName, options);
+  int64be(varName: string, options?: ParserOptions) {
+    this.bigIntVersionCheck();
+    return this.primitiveN('int64be', varName, options);
   }
-  bigint64le(varName: string, options?: ParserOptions) {
-    this.bigIntVerCheck();
-    return this.primitiveN('bigint64le', varName, options);
+  int64le(varName: string, options?: ParserOptions) {
+    this.bigIntVersionCheck();
+    return this.primitiveN('int64le', varName, options);
   }
 
-  biguint64(varName: string, options?: ParserOptions) {
-    this.bigIntVerCheck();
-    return this.primitiveN(this.useThisEndian('biguint64'), varName, options);
+  uint64(varName: string, options?: ParserOptions) {
+    this.bigIntVersionCheck();
+    return this.primitiveN(this.useThisEndian('uint64'), varName, options);
   }
-  biguint64be(varName: string, options?: ParserOptions) {
-    this.bigIntVerCheck();
-    return this.primitiveN('biguint64be', varName, options);
+  uint64be(varName: string, options?: ParserOptions) {
+    this.bigIntVersionCheck();
+    return this.primitiveN('uint64be', varName, options);
   }
-  biguint64le(varName: string, options?: ParserOptions) {
-    this.bigIntVerCheck();
-    return this.primitiveN('biguint64le', varName, options);
+  uint64le(varName: string, options?: ParserOptions) {
+    this.bigIntVersionCheck();
+    return this.primitiveN('uint64le', varName, options);
   }
 
   floatle(varName: string, options?: ParserOptions) {
@@ -699,10 +699,10 @@ export class Parser {
         case 'int16be':
         case 'int32le':
         case 'int32be':
-        case 'bigint64be':
-        case 'bigint64le':
-        case 'biguint64be':
-        case 'biguint64le':
+        case 'int64be':
+        case 'int64le':
+        case 'uint64be':
+        case 'uint64le':
         case 'floatle':
         case 'floatbe':
         case 'doublele':

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -48,6 +48,10 @@ type PrimitiveTypes =
   | 'int16be'
   | 'int32le'
   | 'int32be'
+  | 'biguint64le'
+  | 'biguint64be'
+  | 'bigint64le'
+  | 'bigint64be'
   | 'floatle'
   | 'floatbe'
   | 'doublele'
@@ -59,7 +63,9 @@ type PrimitiveTypesWithoutEndian =
   | 'uint32'
   | 'int8'
   | 'int16'
-  | 'int32';
+  | 'int32'
+  | 'bigint64'
+  | 'biguint64';
 
 type BitSizes =
   | 1
@@ -106,6 +112,10 @@ const PRIMITIVE_SIZES: { [key in PrimitiveTypes]: number } = {
   int16be: 2,
   int32le: 4,
   int32be: 4,
+  bigint64be: 8,
+  bigint64le: 8,
+  biguint64be: 8,
+  biguint64le: 8,
   floatle: 4,
   floatbe: 4,
   doublele: 8,
@@ -123,6 +133,10 @@ const CAPITILIZED_TYPE_NAMES: { [key in Types]: string } = {
   int16be: 'Int16BE',
   int32le: 'Int32LE',
   int32be: 'Int32BE',
+  bigint64be: 'BigInt64BE',
+  bigint64le: 'BigInt64LE',
+  biguint64be: 'BigUInt64BE',
+  biguint64le: 'BigUInt64LE',
   floatle: 'FloatLE',
   floatbe: 'FloatBE',
   doublele: 'DoubleLE',
@@ -221,6 +235,38 @@ export class Parser {
   }
   int32be(varName: string, options?: ParserOptions) {
     return this.primitiveN('int32be', varName, options);
+  }
+
+  private bigIntVerCheck() {
+    const [major] = process.version.replace('v', '').split('.');
+    if(Number(major) < 12) {
+      throw new Error(`The methods readBigInt64BE, readBigInt64BE, readBigInt64BE, readBigInt64BE are not avilable in your version of nodejs: ${process.version}, you must use v12 or greater`);
+    }
+  }
+  bigint64(varName: string, options?: ParserOptions) {
+    this.bigIntVerCheck();
+    return this.primitiveN(this.useThisEndian('bigint64'), varName, options);
+  }
+  bigint64be(varName: string, options?: ParserOptions) {
+    this.bigIntVerCheck();
+    return this.primitiveN('bigint64be', varName, options);
+  }
+  bigint64le(varName: string, options?: ParserOptions) {
+    this.bigIntVerCheck();
+    return this.primitiveN('bigint64le', varName, options);
+  }
+
+  biguint64(varName: string, options?: ParserOptions) {
+    this.bigIntVerCheck();
+    return this.primitiveN(this.useThisEndian('biguint64'), varName, options);
+  }
+  biguint64be(varName: string, options?: ParserOptions) {
+    this.bigIntVerCheck();
+    return this.primitiveN('biguint64be', varName, options);
+  }
+  biguint64le(varName: string, options?: ParserOptions) {
+    this.bigIntVerCheck();
+    return this.primitiveN('biguint64le', varName, options);
   }
 
   floatle(varName: string, options?: ParserOptions) {
@@ -649,6 +695,10 @@ export class Parser {
         case 'int16be':
         case 'int32le':
         case 'int32be':
+        case 'bigint64be':
+        case 'bigint64le':
+        case 'biguint64be':
+        case 'biguint64le':
         case 'floatle':
         case 'floatbe':
         case 'doublele':

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -239,8 +239,12 @@ export class Parser {
 
   private bigIntVerCheck() {
     const [major] = process.version.replace('v', '').split('.');
-    if(Number(major) < 12) {
-      throw new Error(`The methods readBigInt64BE, readBigInt64BE, readBigInt64BE, readBigInt64BE are not avilable in your version of nodejs: ${process.version}, you must use v12 or greater`);
+    if (Number(major) < 12) {
+      throw new Error(
+        `The methods readBigInt64BE, readBigInt64BE, readBigInt64BE, readBigInt64BE are not avilable in your version of nodejs: ${
+          process.version
+        }, you must use v12 or greater`
+      );
     }
   }
   bigint64(varName: string, options?: ParserOptions) {

--- a/test/primitive_parser.js
+++ b/test/primitive_parser.js
@@ -19,13 +19,13 @@ describe('Primitive parser', function() {
       var buffer = Buffer.from([0x00, 0xd2, 0x04, 0x00, 0xbc, 0x61, 0x4e]);
       assert.deepEqual(parser.parse(buffer), { a: 0, b: 1234, c: 12345678 });
     });
-    describe.only('BigInt64 parsers', () => {
+    describe('BigInt64 parsers', () => {
       const [major] = process.version.replace('v', '').split('.');
       if (Number(major) >= 12) {
         it('should parse biguints64', () => {
           const parser = Parser.start()
-            .biguint64be('a')
-            .biguint64le('b');
+            .uint64be('a')
+            .uint64le('b');
           // from https://nodejs.org/api/buffer.html#buffer_buf_readbiguint64le_offset
           const buf = Buffer.from([
             0x00,
@@ -46,17 +46,17 @@ describe('Primitive parser', function() {
             0xff,
           ]);
           assert.deepEqual(parser.parse(buf), {
-            a: 4294967295n,
-            b: 18446744069414584320n,
+            a: BigInt('4294967295'),
+            b: BigInt('18446744069414584320'),
           });
         });
 
         it('should parse bigints64', () => {
           const parser = Parser.start()
-            .bigint64be('a')
-            .bigint64le('b')
-            .bigint64be('c')
-            .bigint64le('d');
+            .int64be('a')
+            .int64le('b')
+            .int64be('c')
+            .int64le('d');
           // from https://nodejs.org/api/buffer.html#buffer_buf_readbiguint64le_offset
           const buf = Buffer.from([
             0x00,
@@ -93,10 +93,10 @@ describe('Primitive parser', function() {
             0xff,
           ]);
           assert.deepEqual(parser.parse(buf), {
-            a: 4294967295n,
-            b: -4294967295n,
-            c: 4294967295n,
-            d: -4294967295n,
+            a: BigInt('4294967295'),
+            b: BigInt('-4294967295'),
+            c: BigInt('4294967295'),
+            d: BigInt('-4294967295'),
           });
         });
       } else {

--- a/test/primitive_parser.js
+++ b/test/primitive_parser.js
@@ -19,6 +19,47 @@ describe('Primitive parser', function() {
       var buffer = Buffer.from([0x00, 0xd2, 0x04, 0x00, 0xbc, 0x61, 0x4e]);
       assert.deepEqual(parser.parse(buffer), { a: 0, b: 1234, c: 12345678 });
     });
+    describe.only('BigInt64 parsers', () => {
+      const [major] = process.version.replace('v', '').split('.');
+      if(Number(major) >= 12) {
+        it('should parse biguints64', () => {
+          const parser = Parser.start()
+            .biguint64be('a')
+            .biguint64le('b');
+          // from https://nodejs.org/api/buffer.html#buffer_buf_readbiguint64le_offset
+          const buf = Buffer.from([
+            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff
+          ]);
+          assert.deepEqual(parser.parse(buf), {a: 4294967295n, b: 18446744069414584320n});
+        })  
+
+        it('should parse bigints64', () => {
+          const parser = Parser.start()
+            .bigint64be('a')
+            .bigint64le('b')
+            .bigint64be('c')
+            .bigint64le('d');
+          // from https://nodejs.org/api/buffer.html#buffer_buf_readbiguint64le_offset
+          const buf = Buffer.from([
+            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+            0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
+            0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff
+          ]);
+          assert.deepEqual(parser.parse(buf), {
+            a: 4294967295n,
+            b: -4294967295n,
+            c: 4294967295n,
+            d: -4294967295n,
+          });
+        })
+      } else {
+        it('should throw when run under not v12', () => {
+          assert.throws(() => Parser.start().bigint64('a'));
+        })
+      }
+    })
     it('should use formatter to transform parsed integer', function() {
       var parser = Parser.start()
         .uint8('a', {

--- a/test/primitive_parser.js
+++ b/test/primitive_parser.js
@@ -21,18 +21,35 @@ describe('Primitive parser', function() {
     });
     describe.only('BigInt64 parsers', () => {
       const [major] = process.version.replace('v', '').split('.');
-      if(Number(major) >= 12) {
+      if (Number(major) >= 12) {
         it('should parse biguints64', () => {
           const parser = Parser.start()
             .biguint64be('a')
             .biguint64le('b');
           // from https://nodejs.org/api/buffer.html#buffer_buf_readbiguint64le_offset
           const buf = Buffer.from([
-            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
-            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
           ]);
-          assert.deepEqual(parser.parse(buf), {a: 4294967295n, b: 18446744069414584320n});
-        })  
+          assert.deepEqual(parser.parse(buf), {
+            a: 4294967295n,
+            b: 18446744069414584320n,
+          });
+        });
 
         it('should parse bigints64', () => {
           const parser = Parser.start()
@@ -42,10 +59,38 @@ describe('Primitive parser', function() {
             .bigint64le('d');
           // from https://nodejs.org/api/buffer.html#buffer_buf_readbiguint64le_offset
           const buf = Buffer.from([
-            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
-            0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
-            0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff,
-            0x01, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
+            0x01,
+            0x00,
+            0x00,
+            0x00,
+            0xff,
+            0xff,
+            0xff,
+            0xff,
           ]);
           assert.deepEqual(parser.parse(buf), {
             a: 4294967295n,
@@ -53,13 +98,13 @@ describe('Primitive parser', function() {
             c: 4294967295n,
             d: -4294967295n,
           });
-        })
+        });
       } else {
         it('should throw when run under not v12', () => {
           assert.throws(() => Parser.start().bigint64('a'));
-        })
+        });
       }
-    })
+    });
     it('should use formatter to transform parsed integer', function() {
       var parser = Parser.start()
         .uint8('a', {


### PR DESCRIPTION
Adds {u,}int64 support which was introduced in nodejs 12
https://nodejs.org/api/buffer.html#buffer_buf_readbigint64be_offset

The one conditional on this is that it only supports nodejs v12, and it'll throw a runtime error if you try call it outside of nodejs v12

Closes #26