### PR TITLE
Drop node 8 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "typescript": "^4.0.3"
       },
       "engines": {
-        "node": ">=8.9.0"
+        "node": ">=10"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   },
   "bugs": "http://github.com/keichi/binary-parser/issues",
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
Node 8 reached EoL in 2019. We also do not run CI tests using Node 8. Let's clarify that we support Node 10 or higher.