### PR TITLE
Index parsing context variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,8 @@ You can use some special fields while parsing to traverse your structure. These
 context variables will be removed after the parsing process:
 - `$parent` - This field references the parent structure. This variable will be
   `null` while parsing the root structure.
-  ```js
+
+  ```javascript
   var parser = new Parser()
     .nest("header", {
       type: new Parser().uint32("length"),
@@ -534,10 +535,12 @@ context variables will be removed after the parsing process:
       length: function() {
         return this.$parent.header.length
       }
-    })
+    });
   ```
+
 - `$root` - This field references the root structure.
-  ```js
+
+  ```javascript
   var parser = new Parser()
     .nest("header", {
       type: new Parser().uint32("length"),
@@ -551,8 +554,30 @@ context variables will be removed after the parsing process:
             return this.$root.header.length
           }
         }),
-    })
+    });
+  ```
 
+- `$index` - This field references the actual index in array parsing. This
+  variable will be available only when using the `length` mode for arrays.
+
+  ```javascript
+  var parser = new Parser()
+    .nest("header", {
+      type: new Parser().uint32("length"),
+    })
+    .nest("data", {
+      type: new Parser()
+        .uint32("value")
+        .array("data", {
+          type: new Parser().nest({
+            type: new Parser().uint8("_tmp"),
+            formatter: function(item) {
+              return this.$index % 2 === 0 ? item._tmp : String.fromCharCode(item._tmp);
+            }
+          }),
+          length: "$root.header.length"
+        }),
+    });
   ```
 
 ## Examples

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -9,7 +9,7 @@ interface ParserOptions {
   assert?: number | string | ((item: number | string) => boolean);
   lengthInBytes?: number | string | ((item: any) => number);
   type?: string | Parser;
-  formatter?: (item: any) => string | number;
+  formatter?: (item: any) => any;
   encoding?: string;
   readUntil?: 'eof' | ((item: any, buffer: Buffer) => boolean);
   greedy?: boolean;

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -686,22 +686,23 @@ export class Parser {
   }
 
   private addAliasedCode(ctx: Context) {
-    ctx.pushCode(
-      `function ${FUNCTION_PREFIX + this.alias}(offset, parent, root) {`
-    );
+    ctx.pushCode(`function ${FUNCTION_PREFIX + this.alias}(offset, context) {`);
     ctx.pushCode(
       `var vars = ${this.constructorFn ? 'new constructorFn()' : '{}'};`
     );
-    ctx.pushCode('vars.$parent = parent || null;');
-    ctx.pushCode('vars.$root = root || vars;');
+    ctx.pushCode(
+      `var ctx = Object.assign({$parent: null, $root: vars}, context || {})`
+    );
+    ctx.pushCode(`vars = Object.assign(vars, ctx)`);
 
     this.generate(ctx);
 
     ctx.markResolved(this.alias);
     this.resolveReferences(ctx);
 
-    ctx.pushCode('delete vars.$parent;');
-    ctx.pushCode('delete vars.$root;');
+    ctx.pushCode(
+      'Object.keys(ctx).forEach(function (item) { delete vars[item]; });'
+    );
     ctx.pushCode('return { offset: offset, result: vars };');
     ctx.pushCode('}');
 
@@ -1094,11 +1095,13 @@ export class Parser {
       } else {
         const parentVar = ctx.generateVariable();
         const tempVar = ctx.generateTmpVariable();
-        ctx.pushCode(
-          `var ${tempVar} = ${
-            FUNCTION_PREFIX + type
-          }(offset, ${parentVar}, ${parentVar}.$root);`
-        );
+        ctx.pushCode(`var ${tempVar} = ${FUNCTION_PREFIX + type}(offset, {`);
+        ctx.pushCode(`$parent: ${parentVar},`);
+        ctx.pushCode(`$root: ${parentVar}.$root,`);
+        if (!this.options.readUntil && lengthInBytes === undefined) {
+          ctx.pushCode(`$index: ${length} - ${counter},`);
+        }
+        ctx.pushCode(`});`);
         ctx.pushCode(
           `var ${item} = ${tempVar}.result; offset = ${tempVar}.offset;`
         );
@@ -1111,9 +1114,13 @@ export class Parser {
       ctx.pushScope(item);
       ctx.pushCode(`${item}.$parent = ${parentVar};`);
       ctx.pushCode(`${item}.$root = ${parentVar}.$root;`);
+      if (!this.options.readUntil && lengthInBytes === undefined) {
+        ctx.pushCode(`${item}.$index = ${length} - ${counter},`);
+      }
       type.generate(ctx);
       ctx.pushCode(`delete ${item}.$parent`);
       ctx.pushCode(`delete ${item}.$root`);
+      ctx.pushCode(`delete ${item}.$index`);
       ctx.popScope();
     }
 
@@ -1150,11 +1157,10 @@ export class Parser {
         ctx.pushCode(`offset += ${PRIMITIVE_SIZES[type as PrimitiveTypes]}`);
       } else {
         const tempVar = ctx.generateTmpVariable();
-        ctx.pushCode(
-          `var ${tempVar} = ${
-            FUNCTION_PREFIX + type
-          }(offset, ${varName}.$parent, ${varName}.$root);`
-        );
+        ctx.pushCode(`var ${tempVar} = ${FUNCTION_PREFIX + type}(offset, {`);
+        ctx.pushCode(`$parent: ${varName}.$parent,`);
+        ctx.pushCode(`$root: ${varName}.$root,`);
+        ctx.pushCode(`});`);
         ctx.pushCode(
           `${varName} = ${tempVar}.result; offset = ${tempVar}.offset;`
         );
@@ -1221,10 +1227,11 @@ export class Parser {
       const parentVar = ctx.generateVariable();
       const tempVar = ctx.generateTmpVariable();
       ctx.pushCode(
-        `var ${tempVar} = ${
-          FUNCTION_PREFIX + this.options.type
-        }(offset, ${parentVar}, ${parentVar}.$root);`
+        `var ${tempVar} = ${FUNCTION_PREFIX + this.options.type}(offset, {`
       );
+      ctx.pushCode(`$parent: ${parentVar},`);
+      ctx.pushCode(`$root: ${parentVar}.$root,`);
+      ctx.pushCode(`});`);
       ctx.pushCode(
         `${nestVar} = ${tempVar}.result; offset = ${tempVar}.offset;`
       );
@@ -1337,10 +1344,11 @@ export class Parser {
       const parentVar = ctx.generateVariable();
       const tempVar = ctx.generateTmpVariable();
       ctx.pushCode(
-        `var ${tempVar} = ${
-          FUNCTION_PREFIX + this.options.type
-        }(offset, ${parentVar}, ${parentVar}.$root);`
+        `var ${tempVar} = ${FUNCTION_PREFIX + this.options.type}(offset, {`
       );
+      ctx.pushCode(`$parent: ${parentVar},`);
+      ctx.pushCode(`$root: ${parentVar}.$root,`);
+      ctx.pushCode(`});`);
       ctx.pushCode(
         `${nestVar} = ${tempVar}.result; offset = ${tempVar}.offset;`
       );

--- a/test/composite_parser.js
+++ b/test/composite_parser.js
@@ -64,16 +64,19 @@ const suite = (Buffer) =>
       });
       it('should parse array of user defined types and have access to parent context', function () {
         var elementParser = new Parser().uint8('key').array('value', {
-          type: "uint8",
+          type: 'uint8',
           length: function () {
             return this.$parent.valueLength;
-          }
+          },
         });
 
-        var parser = Parser.start().uint16le('length').uint16le('valueLength').array('message', {
-          length: 'length',
-          type: elementParser,
-        });
+        var parser = Parser.start()
+          .uint16le('length')
+          .uint16le('valueLength')
+          .array('message', {
+            length: 'length',
+            type: elementParser,
+          });
 
         var buffer = Buffer.from([
           0x02,
@@ -97,17 +100,20 @@ const suite = (Buffer) =>
         });
       });
       it('should parse array of user defined types and have access to root context', function () {
-        var elementParser = new Parser().uint8('key').nest("data", {
+        var elementParser = new Parser().uint8('key').nest('data', {
           type: new Parser().array('value', {
-            type: "uint8",
-            length: "$root.valueLength"
-          })
+            type: 'uint8',
+            length: '$root.valueLength',
+          }),
         });
 
-        var parser = Parser.start().uint16le('length').uint16le('valueLength').array('message', {
-          length: 'length',
-          type: elementParser,
-        });
+        var parser = Parser.start()
+          .uint16le('length')
+          .uint16le('valueLength')
+          .array('message', {
+            length: 'length',
+            type: elementParser,
+          });
 
         var buffer = Buffer.from([
           0x02,
@@ -125,8 +131,8 @@ const suite = (Buffer) =>
           length: 0x02,
           valueLength: 0x02,
           message: [
-            { key: 0xca, data: {value: [0xd2, 0x04]} },
-            { key: 0xbe, data: {value: [0xd3, 0x04]} },
+            { key: 0xca, data: { value: [0xd2, 0x04] } },
+            { key: 0xbe, data: { value: [0xd3, 0x04] } },
           ],
         });
       });
@@ -474,7 +480,6 @@ const suite = (Buffer) =>
           ],
         });
       });
-
       it('should allow parent parser attributes as choice key', function () {
         var ChildParser = Parser.start().choice('data', {
           tag: function (vars) {
@@ -924,7 +929,7 @@ const suite = (Buffer) =>
               1: Parser.start()
                 .uint8('length')
                 .string('message', { length: 'length' })
-                .array('value', { type: "uint8", length: "$parent.items"}),
+                .array('value', { type: 'uint8', length: '$parent.items' }),
               3: Parser.start().int32le('number'),
             },
           });
@@ -1050,11 +1055,11 @@ const suite = (Buffer) =>
         var parser = Parser.start()
           .uint8('items')
           .nest('data', {
-              type: Parser.start()
-                .uint8('length')
-                .string('message', { length: 'length' })
-                .array('value', { type: "uint8", length: "$parent.items"}),
-            });
+            type: Parser.start()
+              .uint8('length')
+              .string('message', { length: 'length' })
+              .array('value', { type: 'uint8', length: '$parent.items' }),
+          });
 
         var buffer = Buffer.from([
           0x2,


### PR DESCRIPTION
This PR adds an `$index` variable for array parsing. I've only implemented this for the `length` parsing option. Also, this PR refactors the way context variables are added to a named parser to make it more easy to extend if needed.