### PR TITLE
Removed typo on code generation

### DIFF
--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -1115,7 +1115,7 @@ export class Parser {
       ctx.pushCode(`${item}.$parent = ${parentVar};`);
       ctx.pushCode(`${item}.$root = ${parentVar}.$root;`);
       if (!this.options.readUntil && lengthInBytes === undefined) {
-        ctx.pushCode(`${item}.$index = ${length} - ${counter},`);
+        ctx.pushCode(`${item}.$index = ${length} - ${counter};`);
       }
       type.generate(ctx);
       ctx.pushCode(`delete ${item}.$parent;`);


### PR DESCRIPTION
This typo can cause some bugged parsers on certain conditions. For example, an array parsing before a choice parsing