### PR TITLE
chore: set shared tsc target (ES6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc",
-    "build:esm": "tsc --target esnext --module esnext --outDir dist/esm && mv dist/esm/binary_parser.js dist/esm/binary_parser.mjs",
+    "build:cjs": "tsc --module commonjs",
+    "build:esm": "tsc --module esnext --outDir dist/esm && mv dist/esm/binary_parser.js dist/esm/binary_parser.mjs",
     "fmt": "prettier --write \"{lib,example,test,benchmark}/**/*.{ts,js}\"",
     "check-fmt": "prettier --list-different \"{lib,example,test,benchmark}/**/*.{ts,js}\"",
     "test": "mocha",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "target": "es2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2018",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
The commonjs & esm builds have different tsc targets ('es5' & 'esnext'). The javascript `class` was introduced in es6 (I believe), so the `Parser`s exported from the cjs & esm builds are different due to transpilation and have different characteristics. Example:

```javascript
import { Parser } from 'binary-parser'; // esm
class MyParser extends Parser { ... } // works because Parser is a javascript class and can be extended
```

```javascript
const { Parser } = require('binary-parser');
class MyParser extends Parser { ... } // Parser isn't a class for cjs output so this doesn't work correctly..
```

~This PR sets the target output to es2018, which is a modern target and [100% compatible with node >= 10]( https://stackoverflow.com/a/57607634/11008641). This way the only difference between the CJS & ESM builds is the module system.~

The target has been changed to ES6.