### PR TITLE
Escape assert strings

### DIFF
--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -1003,7 +1003,9 @@ export class Parser {
         ctx.pushCode(`if (${this.options.assert} !== ${varName}) {`);
         break;
       case "string":
-        ctx.pushCode(`if (${JSON.stringify(this.options.assert)} !== ${varName}) {`);
+        ctx.pushCode(
+          `if (${JSON.stringify(this.options.assert)} !== ${varName}) {`
+        );
         break;
       default:
         throw new Error(

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -1003,7 +1003,7 @@ export class Parser {
         ctx.pushCode(`if (${this.options.assert} !== ${varName}) {`);
         break;
       case "string":
-        ctx.pushCode(`if ("${this.options.assert}" !== ${varName}) {`);
+        ctx.pushCode(`if (${JSON.stringify(this.options.assert)} !== ${varName}) {`);
         break;
       default:
         throw new Error(


### PR DESCRIPTION
This fixes .string("var", "string with \n in it")