### PR TITLE
fix test: specify array type

### DIFF
--- a/test/primitive_parser.ts
+++ b/test/primitive_parser.ts
@@ -117,7 +117,7 @@ function primitiveParserTests(
 
     describe("Bit field parsers", () => {
       function binaryLiteral(s: string): Uint8Array {
-        const bytes = [];
+        const bytes = Array<number>();
 
         s = s.replace(/\s/g, "");
         deepStrictEqual(s.length % 8, 0);


### PR DESCRIPTION
In [test/primitive_parser.ts:125](https://github.com/keichi/binary-parser/blob/8eacd3e004d8b16a4b2f265cef0bd409f51074ad/test/primitive_parser.ts#L125)

```
    bytes.push(parseInt(s.slice(i, i + 8), 2));
```

There is an error if we open the file in VS Code:

```
Argument of type 'number' is not assignable to parameter of type 'never'.ts(2345)
```

This is because on [line 120](https://github.com/keichi/binary-parser/blob/8eacd3e004d8b16a4b2f265cef0bd409f51074ad/test/primitive_parser.ts#L120):

```
const bytes = [];
```

The type of `bytes` is inferred as `never[]`. This patch solves the problem by explicitly initializing `bytes` to an empty `number` array.