### PR TITLE
Fix source map by uploading entire dist folder with map files and lib folder with source

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepare": "npm run build"
   },
   "files": [
-    "dist/**/*.{js,mjs,d.ts}",
+    "dist",
     "lib"
   ],
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "prepare": "npm run build"
   },
   "files": [
-    "dist/**/*.{js,mjs,d.ts}"
+    "dist/**/*.{js,mjs,d.ts}",
+    "lib"
   ],
   "keywords": [
     "binary",


### PR DESCRIPTION
This PR may help with complaints from build systems like webpack 5 and perhaps improve some source maps

```

WARNING in ../../node_modules/binary-parser/dist/esm/binary_parser.mjs
Module Warning (from ../../node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/home/cdiesh/src/jbrowse-components/node_modules/binary-parser/dist/esm/binary_parser.js.map' file: Error: ENOENT: no such file or directory, open '/home/cdiesh/src/jbrowse-components/node_modules/binary-parser/dist/esm/binary_parser.js.map'
```

The entire lib and dist folder are used. The dist folder map files are currently not deployed but are referred to be the js files in dist, and the map files, if deployed, would refer to the lib folder. I've made some similar PRs like https://github.com/satya164/react-simple-code-editor/pull/93/files