### PR TITLE
Don't assume nest contains a bit field

### DIFF
--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -286,7 +286,7 @@ export class Parser {
   alias?: string;
   useContextVariables = false;
 
-  constructor() { }
+  constructor() {}
 
   static start() {
     return new Parser();
@@ -1046,13 +1046,7 @@ export class Parser {
         if (this.next.options && this.next.options.type instanceof Parser) {
           // Something in the nest
           if (this.next.options.type.next) {
-            if (this.next.options.type.next.type === "bit") {
-              // Next is a bit field
-              return false;
-            } else {
-              // Next is something elses
-              return true;
-            }
+            return this.next.options.type.next.type !== "bit";
           }
           return false;
         } else {
@@ -1077,10 +1071,7 @@ export class Parser {
     parser.varName = ctx.generateVariable(parser.varName);
     ctx.bitFields.push(parser);
 
-    if (
-      !this.next ||
-      this.nextNotBit()
-    ) {
+    if (!this.next || this.nextNotBit()) {
       const val = ctx.generateTmpVariable();
 
       ctx.pushCode(`var ${val} = 0;`);
@@ -1127,7 +1118,8 @@ export class Parser {
           if (rem) {
             const mask = -1 >>> (32 - rem);
             ctx.pushCode(
-              `${parser.varName} = (${val} & 0x${mask.toString(16)}) << ${length - rem
+              `${parser.varName} = (${val} & 0x${mask.toString(16)}) << ${
+                length - rem
               };`
             );
             length -= rem;
@@ -1139,7 +1131,8 @@ export class Parser {
         const mask = -1 >>> (32 - length);
 
         ctx.pushCode(
-          `${parser.varName} ${length < (parser.options.length as number) ? "|=" : "="
+          `${parser.varName} ${
+            length < (parser.options.length as number) ? "|=" : "="
           } ${val} >> ${offset} & 0x${mask.toString(16)};`
         );
 


### PR DESCRIPTION
This should be a fix for Issue #240. Previously a bit field followed by a nest would generate parser code in the wrong order. This PR adds additional logic to determine if the next field is a bit field or not. If the next parser is a nest, we now examine the first field in it. I'll try to add some additional test cases but just want to get this open so the review process can start. Currently all test cases pass. 