### PR TITLE
Use DataView instead of Buffer in hand-written benchmark

### DIFF
--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -1,8 +1,8 @@
-const Benchmark = require("benchmark");
-const bp = require("binparse").bp;
-const Parser = require("../dist/binary_parser").Parser;
-const Destruct = require("destruct-js");
-const Struct = require("structron");
+import Benchmark from "benchmark";
+import { bp } from "binparse";
+import { Parser } from "../dist/binary_parser.js";
+import Destruct from "destruct-js";
+import Struct from "structron";
 
 const suite = new Benchmark.Suite();
 
@@ -14,8 +14,8 @@ const PointParser = bp.object("Point", {
 });
 
 const PointsParser = bp.object("SimpleObject", {
-  length: bp.variable("len", bp.lu32),
-  points: bp.array("Points", PointParser, "len"),
+  length: bp.lu32,
+  points: bp.array("Points", PointParser, "length"),
 });
 
 // binary-parser

--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -64,13 +64,14 @@ for (let i = 0; i < n; i++) {
 // Run benchmarks
 suite
   .add("hand-written", function () {
-    const n = buf.readUInt32LE(0);
+    const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+    const n = view.getUint32(0, true);
     const points = [];
     for (let i = 0; i < n; i++) {
       points.push({
-        x: buf.readUInt16LE(i * 6 + 0 + 4),
-        y: buf.readUInt16LE(i * 6 + 2 + 4),
-        z: buf.readUInt16LE(i * 6 + 4 + 4),
+        x: view.getUint16(i * 6 + 0 + 4, true),
+        y: view.getUint16(i * 6 + 2 + 4, true),
+        z: view.getUint16(i * 6 + 4 + 4, true),
       });
     }
   })

--- a/benchmark/package-lock.json
+++ b/benchmark/package-lock.json
@@ -6,8 +6,8 @@
     "": {
       "dependencies": {
         "benchmark": "^2.1.4",
-        "binparse": "1.2.1",
-        "destruct-js": "^0.2.9",
+        "binparse": "^2.1.0",
+        "destruct-js": "^0.2.13",
         "structron": "^0.4.3"
       }
     },
@@ -21,14 +21,17 @@
       }
     },
     "node_modules/binparse": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/binparse/-/binparse-1.2.1.tgz",
-      "integrity": "sha512-3kwsgGE5vELlwhFHFGl/xQfm3QzVMqh+JQLEmLeHlssiEISvq6yc3NXsvsa6jirbZwsg/eZU4gXquY8pLHzV6Q=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binparse/-/binparse-2.1.0.tgz",
+      "integrity": "sha512-aHbVgEQnWpPc4nlK7ZdPedEXFoufVwRCJkp2oZ4nHnSCuwt1Fx/jVPNLOaq3120uNmk3dip5RH/jxI76OA22dw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/destruct-js": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/destruct-js/-/destruct-js-0.2.9.tgz",
-      "integrity": "sha512-7c64QwKLYgK/n4buoyKW9tB1kwAXMvlg2CxrM9BibPpO9br6AssJlF9L8xhXzqqlZy+DfxxzXnTWDhkcUJXerA=="
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/destruct-js/-/destruct-js-0.2.13.tgz",
+      "integrity": "sha512-A5BL4uFygS0I12qNIPEzEqIqQfhkkr49o674SDFXsoHbX2Fg7/+vYgZen8l6GgJ0ezNrAyT9+5MZzBOY37ccjg=="
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -57,14 +60,14 @@
       }
     },
     "binparse": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/binparse/-/binparse-1.2.1.tgz",
-      "integrity": "sha512-3kwsgGE5vELlwhFHFGl/xQfm3QzVMqh+JQLEmLeHlssiEISvq6yc3NXsvsa6jirbZwsg/eZU4gXquY8pLHzV6Q=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binparse/-/binparse-2.1.0.tgz",
+      "integrity": "sha512-aHbVgEQnWpPc4nlK7ZdPedEXFoufVwRCJkp2oZ4nHnSCuwt1Fx/jVPNLOaq3120uNmk3dip5RH/jxI76OA22dw=="
     },
     "destruct-js": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/destruct-js/-/destruct-js-0.2.9.tgz",
-      "integrity": "sha512-7c64QwKLYgK/n4buoyKW9tB1kwAXMvlg2CxrM9BibPpO9br6AssJlF9L8xhXzqqlZy+DfxxzXnTWDhkcUJXerA=="
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/destruct-js/-/destruct-js-0.2.13.tgz",
+      "integrity": "sha512-A5BL4uFygS0I12qNIPEzEqIqQfhkkr49o674SDFXsoHbX2Fg7/+vYgZen8l6GgJ0ezNrAyT9+5MZzBOY37ccjg=="
     },
     "lodash": {
       "version": "4.17.21",

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,8 +1,9 @@
 {
   "dependencies": {
     "benchmark": "^2.1.4",
-    "binparse": "1.2.1",
-    "destruct-js": "^0.2.9",
+    "binparse": "^2.1.0",
+    "destruct-js": "^0.2.13",
     "structron": "^0.4.3"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
This will make the benchmark a lot fairer as DataView is pretty optimized in node.js and also because binary-parser itself uses DataView instead of Buffer. Also i upgraded to binparse@2.

Example Results on my machine (Macbook M1 MacOS 14.1).

Before this change:
```
❯ node bench.js
hand-written x 51,715 ops/sec ±0.35% (100 runs sampled)
binparse x 19,540 ops/sec ±0.58% (96 runs sampled)
binary-parser x 149,758 ops/sec ±0.58% (96 runs sampled)
destruct-js x 843 ops/sec ±0.17% (99 runs sampled)
structron x 7,554 ops/sec ±0.55% (97 runs sampled)
Fastest is binary-parser
```

After this change:
```
❯ node bench.js
hand-written x 153,338 ops/sec ±1.84% (95 runs sampled)
binparse x 136,028 ops/sec ±3.38% (92 runs sampled)
binary-parser x 153,768 ops/sec ±0.70% (91 runs sampled)
destruct-js x 844 ops/sec ±0.32% (99 runs sampled)
structron x 7,697 ops/sec ±0.31% (100 runs sampled)
Fastest is hand-written
```

That's more than tripple the speed for the hand-written implementation than before.