### PR TITLE
Bugfix: Make `pointer` accept offset=0

### DIFF
--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -286,7 +286,7 @@ export class Parser {
   alias?: string;
   useContextVariables = false;
 
-  constructor() {}
+  constructor() { }
 
   static start() {
     return new Parser();
@@ -706,7 +706,7 @@ export class Parser {
   }
 
   pointer(varName: string, options: ParserOptions): this {
-    if (!options.offset) {
+    if (options.offset == null) {
       throw new Error("offset is required for pointer.");
     }
 
@@ -1118,8 +1118,7 @@ export class Parser {
           if (rem) {
             const mask = -1 >>> (32 - rem);
             ctx.pushCode(
-              `${parser.varName} = (${val} & 0x${mask.toString(16)}) << ${
-                length - rem
+              `${parser.varName} = (${val} & 0x${mask.toString(16)}) << ${length - rem
               };`,
             );
             length -= rem;
@@ -1131,8 +1130,7 @@ export class Parser {
         const mask = -1 >>> (32 - length);
 
         ctx.pushCode(
-          `${parser.varName} ${
-            length < (parser.options.length as number) ? "|=" : "="
+          `${parser.varName} ${length < (parser.options.length as number) ? "|=" : "="
           } ${val} >> ${offset} & 0x${mask.toString(16)};`,
         );
 

--- a/lib/binary_parser.ts
+++ b/lib/binary_parser.ts
@@ -286,7 +286,7 @@ export class Parser {
   alias?: string;
   useContextVariables = false;
 
-  constructor() { }
+  constructor() {}
 
   static start() {
     return new Parser();
@@ -1118,7 +1118,8 @@ export class Parser {
           if (rem) {
             const mask = -1 >>> (32 - rem);
             ctx.pushCode(
-              `${parser.varName} = (${val} & 0x${mask.toString(16)}) << ${length - rem
+              `${parser.varName} = (${val} & 0x${mask.toString(16)}) << ${
+                length - rem
               };`,
             );
             length -= rem;
@@ -1130,7 +1131,8 @@ export class Parser {
         const mask = -1 >>> (32 - length);
 
         ctx.pushCode(
-          `${parser.varName} ${length < (parser.options.length as number) ? "|=" : "="
+          `${parser.varName} ${
+            length < (parser.options.length as number) ? "|=" : "="
           } ${val} >> ${offset} & 0x${mask.toString(16)};`,
         );
 


### PR DESCRIPTION
The current version of `binary-parser` has a type-coercion problem where an offset of 0 will incorrectly be rejected by `.pointer`. It's caused by this block which coerces `offset=0` into false.
```ts
    if (!options.offset) {
      throw new Error("offset is required for pointer.");
    }
```

This PR simply replaces that check with one that accepts 0 but rejects both `undefined` and `null` (`undefined == null` = `true`)