### PR TITLE
Fix broken build status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Binary-parser
 
-[![build](https://github.com/keichi/binary-parser/workflows/build/badge.svg)](https://github.com/keichi/binary-parser/actions?query=workflow%3Abuild)
+[![test-nodejs](https://github.com/keichi/binary-parser/workflows/test-nodejs/badge.svg)](https://github.com/keichi/binary-parser/actions?query=workflow%3Atest-nodejs)
 [![npm](https://img.shields.io/npm/v/binary-parser)](https://www.npmjs.com/package/binary-parser)
 [![license](https://img.shields.io/github/license/keichi/binary-parser)](https://github.com/keichi/binary-parser/blob/master/LICENSE)
 


### PR DESCRIPTION
Update the workflow badge URL from 'build' to 'test-nodejs' to match the actual GitHub Actions workflow name defined in nodejs.yml.